### PR TITLE
Allow to define what's exported

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.9.0",
     "jsdom": "^9.2.1",
+    "postcss-modules": "^0.5.2",
     "postcss-nested": "^1.0.0",
     "require-from-string": "^1.1.0",
     "rollup": "^0.26.3",
@@ -41,7 +42,7 @@
   "dependencies": {
     "postcss": "^5.0.12",
     "rollup-pluginutils": "^1.2.0",
-    "style-inject": "0.0.11"
+    "style-inject": "^0.1.0"
   },
   "ava": {
     "require": [

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export default function (options = {}) {
   const filter = createFilter(options.include, options.exclude);
   const injectFnName = '__$styleInject'
   const extensions = options.extensions || ['.css', '.sss']
+  const getExport = options.getExport || function () {}
 
   return {
     intro() {
@@ -31,7 +32,7 @@ export default function (options = {}) {
       return postcss(options.plugins || [])
           .process(code, opts)
           .then(result => {
-            const code = `export default ${injectFnName}(${JSON.stringify(result.css)});`;
+            const code = `export default ${injectFnName}(${JSON.stringify(result.css)},${JSON.stringify(getExport(result.opts.from))});`;
             const map = options.sourceMap && result.map
               ? JSON.parse(result.map)
               : { mappings: '' };

--- a/test.js
+++ b/test.js
@@ -2,7 +2,8 @@ import test from 'ava';
 import requireFromString from 'require-from-string';
 import {
   buildDefault,
-  buildWithParser
+  buildWithParser,
+  buildWithCssModules
 } from './tests/build';
 
 test('test postcss', async t => {
@@ -18,3 +19,9 @@ test('use sugarss as parser', async t => {
   const styles = window.getComputedStyle(document.body);
   t.is(styles.fontSize, '20px');
 });
+
+test('use cssmodules', async t => {
+  const data = await buildWithCssModules().catch(err => console.log(err.stack));
+  const exported = requireFromString(data);
+  t.regex(exported.trendy, /trendy_/);
+})

--- a/tests/build.js
+++ b/tests/build.js
@@ -68,3 +68,45 @@ export function buildWithParser() {
     return result.code;
   })
 };
+
+export function buildWithCssModules() {
+  const exportMap = {}
+  return rollup({
+    plugins: [
+      postcss({
+        include: '**/*.css',
+        sourceMap: true,
+        plugins: [
+          require('postcss-modules')({
+            getJSON (id, exportTokens) {
+              exportMap[id] = exportTokens;
+            }
+          })
+        ],
+        getExport (id) {
+          return exportMap[id];
+        }
+      }),
+      babel({
+        babelrc: false,
+        presets: ['es2015-rollup'],
+        include: '**/*.js',
+        sourceMap: true
+      }),
+    ],
+    entry: __dirname +'/fixture_modules.js'
+  }).then(bundle => {
+    const result = bundle.generate({
+      format: 'umd',
+      moduleName: 'default',
+      sourceMap: true,
+    });
+    bundle.write({
+      dest: './tests/output_modules.js',
+      moduleName: 'default',
+      format: 'umd',
+      sourceMap: true
+    });
+    return result.code;
+  })
+};

--- a/tests/fixture_modules.css
+++ b/tests/fixture_modules.css
@@ -1,0 +1,3 @@
+.trendy {
+  color: hotpink;
+}

--- a/tests/fixture_modules.js
+++ b/tests/fixture_modules.js
@@ -1,0 +1,2 @@
+import style from './fixture_modules.css';
+export default style;


### PR DESCRIPTION
Optional function to configure the return value of the injected module.

I just wanted to get some feedback on this. It depends on egoist/style-inject#1 and fixes #2

You can configure `rollup` like so

```js
const postcss = require('rollup-plugin-postcss');
const postcssModules = require('postcss-modules');

const cssExportMap = {};

rollup({
   plugins: [
        postcss({
            plugins: [
                postcssModules({
                    getJSON (id, exportTokens) {
                        cssExportMap[id] = exportTokens;
                    }
                })
            ],
            getExport (id) {
                return cssExportMap[id];
            }
        })
   ]
})
```

And it allows you to do

```js
import style from './style.css';

console.log(style.className); // .className_echwj_1
```

I didn't want this plugin to be aware of `postcss-modules` but simply provide a generic way of injecting the exported module.
This approach has the downside of requiring more user configuration but I think is more flexible and can potentially work with other postcss plugins.