### PR TITLE
Add extract option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /index.js
 /tests/output*.js*
+/tests/output*.css*
 
 # Logs
 logs

--- a/test.js
+++ b/test.js
@@ -1,9 +1,11 @@
 import test from 'ava';
+import fs from 'fs';
 import requireFromString from 'require-from-string';
 import {
   buildDefault,
   buildWithParser,
-  buildWithCssModules
+  buildWithCssModules,
+  buildWithExtract
 } from './tests/build';
 
 test('test postcss', async t => {
@@ -24,4 +26,10 @@ test('use cssmodules', async t => {
   const data = await buildWithCssModules().catch(err => console.log(err.stack));
   const exported = requireFromString(data);
   t.regex(exported.trendy, /trendy_/);
+})
+
+test('use extract', async t => {
+  const data = await buildWithExtract().catch(err => console.log(err.stack));
+  const extractedStyles = fs.readFileSync('./tests/output.css');
+  t.regex(extractedStyles, /margin/);
 })

--- a/tests/build.js
+++ b/tests/build.js
@@ -110,3 +110,25 @@ export function buildWithCssModules() {
     return result.code;
   })
 };
+
+export function buildWithExtract() {
+  return rollup({
+    plugins: [
+      postcss({
+        include: '**/*.css',
+        sourceMap: true,
+        extract: './tests/output.css',
+        plugins: [
+          require('postcss-nested')
+        ]
+      }),
+      babel({
+        babelrc: false,
+        presets: ['es2015-rollup'],
+        include: '**/*.js',
+        sourceMap: true
+      }),
+    ],
+    entry: __dirname +'/fixture.js'
+  })
+}


### PR DESCRIPTION
This is in response to #4.

This PR adds an additional option, `extract`, which is expected to be a string or false-y. When a path is provided as the value to `extract`, during the build, a css file will be output to that path.

To achieve this I maintain a mapping of source file name to compiled source and concatenate all compiled sources before writing to disk.

Currently this solution is very inefficient as it will write to the extract destination file as many times as there are source files. I'd imagine that this would be very slow on a large codebase.

If there are hooks for when compilation is complete in rollup, I could use that to trigger a write. I originally thought about appending to the file which would save on rewriting existing output but that solution breaks down when rollup is run in watch mode and an increment build occurs.

Other options could include throttling the disk writing but that could get rather complicated.

I'm happy to make any changes. There wasn't guide on contributing so I just followed my ❤️ .
