### PR TITLE
Add extract option to write combined css and source map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /index.js
 /tests/output*.js*
+/tests/output*.css*
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ import postcss from 'rollup-plugin-postcss';
 rollup({
  plugins: [
     postcss({
-      sourceMap: true, //inline source map
+      sourceMap: true, //true, "inline" or false
       extract : '/path/to/style.css'
     })
  ]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ rollup({
         // cssnext(),
         // yourPostcssPlugin()
       ],
+      //sourceMap: false, // defult value
+      //extract: false, // default value
       extensions: ['.css', '.sss']  // default value
       // parser: sugarss
     })
@@ -77,7 +79,22 @@ import style from './style.css';
 console.log(style.className); // .className_echwj_1
 ```
 
+## Write combined css and source map into a file
 
+```js
+import postcss from 'rollup-plugin-postcss';
+
+rollup({
+ plugins: [
+    postcss({
+      sourceMap: true, //inline source map
+      extract : '/path/to/style.css'
+    })
+ ]
+})
+```
+
+When `extract` is set to `true` the plugin will automatically generate a css file in the same place where the js is created by rollup. The css file will have the same name as the js file.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rollup({
         // cssnext(),
         // yourPostcssPlugin()
       ],
-      //sourceMap: false, // defult value
+      //sourceMap: false, // default value
       //extract: false, // default value
       extensions: ['.css', '.sss']  // default value
       // parser: sugarss

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "concat-with-sourcemaps": "^1.0.4",
     "postcss": "^5.0.12",
     "rollup-pluginutils": "^1.2.0",
-    "style-inject": "^0.1.0"
+    "style-inject": "^0.1.0",
+    "mkdirp": "^0.5.1"
   },
   "ava": {
     "require": [

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import postcss from 'postcss';
 import styleInject from 'style-inject';
 import path from 'path';
 import fs from 'fs';
+import mkdirp from 'mkdirp';
 
 import Concat from 'concat-with-sourcemaps';
 
@@ -44,6 +45,10 @@ export default function (options = {}) {
   const combineStyleTags = !!options.combineStyleTags;
   const extract = options.extract || false;
   const extractPath = (typeof extract == "string")?extract:false;
+
+  if(extractPath) mkdirp(path.dirname(extractPath), err=>{
+      if (err) throw Error(err);
+  });
 
   const concat = new Concat(true, path.basename(extractPath||'styles.css'), '\n');
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,16 +25,24 @@ function writeFilePromise(dest, content) {
     const fileName = path.basename(autoDest, path.extname(autoDest));
     const cssOutputDest = manualDest?manualDest:path.join(path.dirname(autoDest), fileName + '.css');
     let css = source.content.toString("utf8");
+    let promises = [];
+    console.log(fileName);
     if (sourceMap) {
       var map = source.sourceMap;
-      if(manualDest){
+      if(!manualDest){
         map = JSON.parse(map);
         map.file = fileName + '.css';
         map = JSON.stringify(map);
       }
-      css += '\n/*# sourceMappingURL=data:application/json;base64,' + Buffer.from(map, 'utf8').toString('base64') + ' */';
+      if(sourceMap === "inline"){
+        css += '\n/*# sourceMappingURL=data:application/json;base64,' + Buffer.from(map, 'utf8').toString('base64') + ' */';
+      }else{
+        css += `\n//# sourceMappingURL=${fileName}.css.map`;
+        promises.push(writeFilePromise(`${cssOutputDest}.map`, map));
+      }
     }
-    return writeFilePromise(cssOutputDest, css);
+    promises.push(writeFilePromise(cssOutputDest, css));
+    return Promise.all(promises);
  }
 
 export default function (options = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default function (options = {}) {
   const extensions = options.extensions || ['.css', '.sss']
   const getExport = options.getExport || function () {}
   const combineStyleTags = !!options.combineStyleTags;
-  const extract = options.extract || false;
+  const extract = typeof options.extract === 'string' ? options.extract : false;
 
   const concat = new Concat(true, 'styles.css', '\n');
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,13 +11,11 @@ function cwd(file) {
 }
 
 function processExtract(concat, destination, sourceMap){
-  let code = concat.content.toString("utf8");
+  let css = concat.content.toString("utf8");
   if (sourceMap) {
-    const sourceMapDestination = `${destination}.map`;
-    code += `\n/*# sourceMappingURL=${sourceMapDestination} */`;
-    fs.writeFileSync(sourceMapDestination, concat.sourceMap);
+    css += '\n/*# sourceMappingURL=data:application/json;base64,' + Buffer.from(concat.sourceMap, 'utf8').toString('base64') + ' */';
   }
-  fs.writeFileSync(destination, code);
+  fs.writeFileSync(destination, css);
 }
 
 export default function (options = {}) {
@@ -28,7 +26,7 @@ export default function (options = {}) {
   const combineStyleTags = !!options.combineStyleTags;
   const extract = typeof options.extract === 'string' ? options.extract : false;
 
-  const concat = new Concat(true, 'styles.css', '\n');
+  const concat = new Concat(true, path.basename(extract || 'styles.css'), '\n');
 
   const injectStyleFuncCode = styleInject.toString().replace(/styleInject/, injectFnName);
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ function writeFilePromise(dest, content) {
  }
 
  function extractCssAndWriteToFile(source, manualDest, autoDest, sourceMap){
+    if(manualDest) mkdirp(path.dirname(manualDest), err=>{
+        if ( err ) return Promise.reject( err );
+    });
     const fileName = path.basename(autoDest, path.extname(autoDest));
     const cssOutputDest = manualDest?manualDest:path.join(path.dirname(autoDest), fileName + '.css');
     let css = source.content.toString("utf8");
@@ -53,10 +56,6 @@ export default function (options = {}) {
   const combineStyleTags = !!options.combineStyleTags;
   const extract = options.extract || false;
   const extractPath = (typeof extract == "string")?extract:false;
-
-  if(extractPath) mkdirp(path.dirname(extractPath), err=>{
-      if (err) throw Error(err);
-  });
 
   const concat = new Concat(true, path.basename(extractPath||'styles.css'), '\n');
 

--- a/test.js
+++ b/test.js
@@ -41,5 +41,5 @@ test('extract styles', async t => {
   const data = await buildWithExtract().catch(err => console.log(err.stack));
   requireFromString(data);
   const extractedStyles = fs.readFileSync('./tests/output_extract.css');
-  t.regex(extractedStyles, /margin/);
+  t.regex(extractedStyles, /color: hotpink;/);
 })

--- a/test.js
+++ b/test.js
@@ -1,10 +1,12 @@
 import test from 'ava';
 import requireFromString from 'require-from-string';
+import fs from 'fs';
 import {
   buildDefault,
   buildWithParser,
   buildWithCssModules,
-  buildCombinedStyles
+  buildCombinedStyles,
+  buildWithExtract
 } from './tests/build';
 
 test('test postcss', async t => {
@@ -33,4 +35,11 @@ test('combine styles', async t => {
   const styles = window.getComputedStyle(document.body);
   t.is(styles.margin, '0px');
   t.is(styles.fontSize, '20px');
+})
+
+test('extract styles', async t => {
+  const data = await buildWithExtract().catch(err => console.log(err.stack));
+  requireFromString(data);
+  const extractedStyles = fs.readFileSync('./tests/output_extract.css');
+  t.regex(extractedStyles, /margin/);
 })

--- a/test.js
+++ b/test.js
@@ -39,7 +39,6 @@ test('combine styles', async t => {
 
 test('extract styles', async t => {
   const data = await buildWithExtract().catch(err => console.log(err.stack));
-  requireFromString(data);
   const extractedStyles = fs.readFileSync('./tests/output_extract.css');
   t.regex(extractedStyles, /color: hotpink;/);
 })

--- a/tests/build.js
+++ b/tests/build.js
@@ -163,7 +163,7 @@ export function buildWithExtract() {
       postcss({
         include: '**/*.css',
         sourceMap: true,
-        extract: './tests/output_extract.css',
+        extract: true,
         plugins: [
           require('postcss-modules')({
             getJSON (id, exportTokens) {
@@ -184,22 +184,14 @@ export function buildWithExtract() {
     ],
     entry: __dirname +'/fixture_modules.js'
   }).then(bundle => {
-    let promises = [];
 
-    const result = bundle.generate({
-      format: 'umd',
-      moduleName: 'default',
-      sourceMap: true,
-    });
-    const t = bundle.write({
+    return bundle.write({
       dest: './tests/output_extract.js',
       moduleName: 'default',
       format: 'umd',
       sourceMap: true
     });
-    promises.push(result);
-    promises.push(t);
-    return Promise.all(promises);
+
   })
   
 };

--- a/tests/build.js
+++ b/tests/build.js
@@ -184,18 +184,22 @@ export function buildWithExtract() {
     ],
     entry: __dirname +'/fixture_modules.js'
   }).then(bundle => {
+    let promises = [];
+
     const result = bundle.generate({
       format: 'umd',
       moduleName: 'default',
       sourceMap: true,
     });
-    bundle.write({
+    const t = bundle.write({
       dest: './tests/output_extract.js',
       moduleName: 'default',
       format: 'umd',
       sourceMap: true
     });
-    return result.code;
+    promises.push(result);
+    promises.push(t);
+    return Promise.all(promises);
   })
   
 };

--- a/tests/build.js
+++ b/tests/build.js
@@ -155,3 +155,36 @@ export function buildCombinedStyles() {
     return result.code;
   })
 };
+
+export function buildWithExtract() {
+  return rollup({
+    plugins: [
+      postcss({
+        include: '**/*.css',
+        sourceMap: true,
+        extract: './tests/output_extract.css',
+        plugins: [
+          require('postcss-nested')
+        ]
+      }),
+      babel({
+        babelrc: false,
+        presets: [['es2015', {modules: false}]],
+        include: '**/*.js',
+        sourceMap: true
+      }),
+    ],
+    entry: __dirname +'/fixture.js'
+  }).then(bundle => {
+    const result = bundle.generate({
+      format: 'umd',
+      sourceMap: true,
+    });
+    bundle.write({
+      dest: './tests/output_extract.js',
+      format: 'umd',
+      sourceMap: true
+    });
+    return result.code;
+  })
+};

--- a/tests/build.js
+++ b/tests/build.js
@@ -157,6 +157,7 @@ export function buildCombinedStyles() {
 };
 
 export function buildWithExtract() {
+  const exportMap = {}
   return rollup({
     plugins: [
       postcss({
@@ -164,8 +165,15 @@ export function buildWithExtract() {
         sourceMap: true,
         extract: './tests/output_extract.css',
         plugins: [
-          require('postcss-nested')
-        ]
+          require('postcss-modules')({
+            getJSON (id, exportTokens) {
+              exportMap[id] = exportTokens;
+            }
+          })
+        ],
+        getExport (id) {
+          return exportMap[id];
+        }
       }),
       babel({
         babelrc: false,
@@ -174,17 +182,20 @@ export function buildWithExtract() {
         sourceMap: true
       }),
     ],
-    entry: __dirname +'/fixture.js'
+    entry: __dirname +'/fixture_modules.js'
   }).then(bundle => {
     const result = bundle.generate({
       format: 'umd',
+      moduleName: 'default',
       sourceMap: true,
     });
     bundle.write({
       dest: './tests/output_extract.js',
+      moduleName: 'default',
       format: 'umd',
       sourceMap: true
     });
     return result.code;
   })
+  
 };


### PR DESCRIPTION
This is a response to [#4.](https://github.com/egoist/rollup-plugin-postcss/issues/4)

This PR adds an additional option, `extract`, which is expected to be a string or a boolean. When a path is provided as the value to `extract`, at the end of the build, a css file will be output to that path. If `extract` is true(bool) the css file will be output at the same path as the chosen rollup's bundle.write `dest` option.

When the option `sourceMap` is present and true-y an inline source map of the css will also be created.

This solution doesn't break other options and behaviors of the actual plugin.
