### PR TITLE
Remove appending styles in watch mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,26 +62,25 @@ export default function (options = {}) {
 
   return {
     intro() {
-      concat = new Concat(
-        true,
-        path.basename(extractPath || 'styles.css'),
-        '\n'
-      );
-      Object.keys(transformedFiles).forEach(file => {
-        concat.add(
-          file,
-          transformedFiles[file].css,
-          transformedFiles[file].map
+      if (extract || combineStyleTags) {
+        concat = new Concat(
+          true,
+          path.basename(extractPath || 'styles.css'),
+          '\n'
         );
-      });
-
-      if (extract) {
-        return;
+        Object.keys(transformedFiles).forEach(file => {
+          concat.add(
+            file,
+            transformedFiles[file].css,
+            transformedFiles[file].map
+          );
+        });
+        if (combineStyleTags) {
+          return `${injectStyleFuncCode}\n${injectFnName}(${JSON.stringify(concat.content.toString('utf8'))})`;
+        }
+      } else {
+        return injectStyleFuncCode;
       }
-      if (combineStyleTags) {
-        return `${injectStyleFuncCode}\n${injectFnName}(${JSON.stringify(concat.content.toString('utf8'))})`;
-      }
-      return injectStyleFuncCode;
     },
     transform(code, id) {
       if (!filter(id)) {


### PR DESCRIPTION
Hi, I've stumbled upon an interesting bug while trying to configure my dev environment with rollup watch mode (added with `rollup-watch` module). Example:

While using `extract` option and `--watch` flag importing following CSS file:
```
body {
  color: red;
}
```
I am getting correct bundled CSS file. But trying to modify source CSS file, for example:
```
body {
  color: green;
}
```
Results in following bundled CSS:
```
body {
  color: red;
}

body {
  color: green;
}
```

While using watch mode `transform` function is only invoked for modified file. Since `concat-with-sourcemaps` is initialized before and support only `add` method all modified files are appended to existing content. I would qualify my fix as a hack since it is basically storing all the CSS files and concatenating them before write (would be great if `concat-with-sourcemaps` supported some kind of `replace` method), I don't believe that it is affecting in any way bundling without watch mode.

I didn't write any tests for this case yet. I thought it would be better to ask first if this solution is worth pursuing. I've also done some very minor formatting changes during development.