### PR TITLE
#14 option to not default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ import style from './style.css';
 
 console.log(style.className); // .className_echwj_1
 ```
+You also can import only a specific CSS className like this:
+
+```js
+import {className} from './style.css';
+
+console.log(className); // .className_echwj_2
+```
 
 ### Extract CSS
 

--- a/test/fixtures/fixture_modules.css
+++ b/test/fixtures/fixture_modules.css
@@ -1,3 +1,6 @@
 .trendy {
   color: hotpink;
 }
+.bar{
+  color: cyan;
+}

--- a/test/fixtures/fixture_modules.js
+++ b/test/fixtures/fixture_modules.js
@@ -1,2 +1,2 @@
-import style from './fixture_modules.css';
-export default style;
+import style, {bar} from './fixture_modules.css';
+export default {style, bar};

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,8 @@ test('use sugarss as parser', async t => {
 test('use cssmodules', async t => {
   const data = await buildWithCssModules().catch(err => console.log(err.stack));
   const exported = requireFromString(data);
-  t.regex(exported.trendy, /trendy_/);
+  t.regex(exported.style.trendy, /trendy_/);
+  t.regex(exported.bar, /bar_/);
 });
 
 test('combine styles', async t => {


### PR DESCRIPTION
When using the plugin `postcss-modules` allow for exporting each individual generated className apart from the default style object.

So now we can use :
`import {specificClassName} from "style.css"`

This PR is a response to #14