### PR TITLE
camlCase dashes for css modules exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ import {className} from './style.css';
 
 console.log(className); // .className_echwj_2
 ```
+Also, note that all your dashed class names will be transformed to camlCased one when it be individually imported, but the original will not be removed from the locals. For example:
+
+```css
+.class-name {}
+```
+```js
+import style, { className } from './style.css';
+console.log(style['class-name'] === className) // true
+```
 
 ### Extract CSS
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,12 @@ import postcss from 'postcss';
 import styleInject from 'style-inject';
 import Concat from 'concat-with-sourcemaps';
 
+function dashesCamelCase(str) {
+  return str.replace(/-(\w)/g, (match, firstLetter) => {
+    return firstLetter.toUpperCase();
+  });
+}
+
 function cwd(file) {
   return path.join(process.cwd(), file);
 }
@@ -115,7 +121,11 @@ export default function (options = {}) {
               if (getExport) {
                 codeExportDefault = getExport(result.opts.from);
                 Object.keys(codeExportDefault).forEach(k => {
-                  codeExportSparse += `export const ${k}=${JSON.stringify(codeExportDefault[k])};\n`;
+                  const camelCasedKey = dashesCamelCase(k);
+                  codeExportSparse += `export const ${camelCasedKey}=${JSON.stringify(codeExportDefault[k])};\n`;
+                  if (camelCasedKey !== k) {
+                    codeExportDefault[camelCasedKey] = codeExportDefault[k];
+                  }
                 });
               }
 

--- a/test/fixtures/fixture_modules.css
+++ b/test/fixtures/fixture_modules.css
@@ -1,6 +1,9 @@
 .trendy {
   color: hotpink;
 }
-.bar{
+.foo_bar {
+  color: blue;
+}
+.foo-bar {
   color: cyan;
 }

--- a/test/fixtures/fixture_modules.js
+++ b/test/fixtures/fixture_modules.js
@@ -1,2 +1,2 @@
-import style, {bar} from './fixture_modules.css';
-export default {style, bar};
+import style, {fooBar, foo_bar} from './fixture_modules.css';
+export default {style, fooBar, foo_bar};

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,9 @@ test('use cssmodules', async t => {
   const data = await buildWithCssModules().catch(err => console.log(err.stack));
   const exported = requireFromString(data);
   t.regex(exported.style.trendy, /trendy_/);
-  t.regex(exported.bar, /bar_/);
+  t.regex(exported.style.fooBar, /foo-bar_/);
+  t.regex(exported.fooBar, /foo-bar_/);
+  t.regex(exported.foo_bar, /foo_bar_/);
 });
 
 test('combine styles', async t => {


### PR DESCRIPTION
This PR is trying to fix an issue where exporting a selector which including dashes like `.foo-bar` when using css modules. Since now we are generating `export const foo-bar = "....."` and the dashes are illegal for javascript variables, the whole build phrase would fail.

I'm just implementing `camelCase: 'dashes'` option in [webpack-style-loader](https://github.com/webpack-contrib/css-loader#camelcase). It's fairly enough for my use cases.