### PR TITLE
fix js reserved keyword as classname

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "xo": "^0.18.2"
   },
   "dependencies": {
+    "chalk": "^1.1.3",
     "concat-with-sourcemaps": "^1.0.4",
     "fs-extra": "^3.0.1",
     "postcss": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "concat-with-sourcemaps": "^1.0.4",
     "fs-extra": "^3.0.1",
     "postcss": "^6.0.1",
+    "reserved-words": "^0.1.1",
     "rollup-pluginutils": "^2.0.1",
     "style-inject": "^0.1.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { createFilter } from 'rollup-pluginutils'
 import postcss from 'postcss'
 import styleInject from 'style-inject'
 import Concat from 'concat-with-sourcemaps'
+import reserved from 'reserved-words'
 
 function dashesCamelCase(str) {
   return str.replace(/-(\w)/g, (match, firstLetter) => {
@@ -134,7 +135,9 @@ export default function(options = {}) {
                 codeExportDefault = getExport(result.opts.from)
                 Object.keys(codeExportDefault).forEach(k => {
                   const camelCasedKey = dashesCamelCase(k)
-                  codeExportSparse += `export const ${camelCasedKey}=${JSON.stringify(codeExportDefault[k])};\n`
+                  if (!reserved.check(camelCasedKey)) {
+                    codeExportSparse += `export const ${camelCasedKey}=${JSON.stringify(codeExportDefault[k])};\n`
+                  }
                   if (camelCasedKey !== k) {
                     codeExportDefault[camelCasedKey] = codeExportDefault[k]
                   }

--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,16 @@ export default function(options = {}) {
                 codeExportDefault = getExport(result.opts.from)
                 Object.keys(codeExportDefault).forEach(k => {
                   const camelCasedKey = dashesCamelCase(k)
-                  if (!reserved.check(camelCasedKey)) {
+                  if (reserved.check(camelCasedKey)) {
+                    console.warn(
+                      '\x1b[33m:',
+                      'You are using a reserved keyword',
+                      '\x1b[32m',
+                      camelCasedKey,
+                      '\x1b[33m',
+                      "as className so it's not available in named exports"
+                    )
+                  } else {
                     codeExportSparse += `export const ${camelCasedKey}=${JSON.stringify(codeExportDefault[k])};\n`
                   }
                   if (camelCasedKey !== k) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import postcss from 'postcss'
 import styleInject from 'style-inject'
 import Concat from 'concat-with-sourcemaps'
 import reserved from 'reserved-words'
+import chalk from 'chalk'
 
 function dashesCamelCase(str) {
   return str.replace(/-(\w)/g, (match, firstLetter) => {
@@ -137,13 +138,13 @@ export default function(options = {}) {
                   const camelCasedKey = dashesCamelCase(k)
                   if (reserved.check(camelCasedKey)) {
                     console.warn(
-                      '\x1b[33m:',
-                      'You are using a reserved keyword',
-                      '\x1b[32m',
-                      camelCasedKey,
-                      '\x1b[33m',
-                      "as className so it's not available in named exports"
+                      chalk.yellow('You are using a reserved keyword'),
+                      chalk.cyan(camelCasedKey),
+                      chalk.yellow(
+                        "as className so it's not available in named exports"
+                      )
                     )
+                    console.warn(chalk.dim(`location: ${id}`))
                   } else {
                     codeExportSparse += `export const ${camelCasedKey}=${JSON.stringify(codeExportDefault[k])};\n`
                   }

--- a/test/fixtures/fixture_modules.css
+++ b/test/fixtures/fixture_modules.css
@@ -7,3 +7,6 @@
 .foo-bar {
   color: cyan;
 }
+.switch: {
+  color: green;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,6 +3756,10 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reserved-words@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.1.tgz#6f7c15e5e5614c50da961630da46addc87c0cef2"
+
 resolve-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz#4eaeea41ed040d1702457df64a42b2b07d246f9f"


### PR DESCRIPTION
This PR is trying to fix an issue when using js reserved keywords like `switch` as css class names.

Though I can't figure out how to write the test for this case, the tests would throw the error without this patch.