### PR TITLE
Make dash escaping and named exports optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ export default {
       ],
       //sourceMap: false, // default value
       //extract: false, // default value
+      //exportNamed: false, // default value
+      //escapeDashes: false, // default value
       extensions: ['.css', '.sss']  // default value
       // parser: sugarss
     })
@@ -88,21 +90,21 @@ import style from './style.css';
 
 console.log(style.className); // .className_echwj_1
 ```
-You also can import only a specific CSS className like this:
+When `exportNamed` is set to `true`, you also can import only a specific CSS className like this:
 
 ```js
 import {className} from './style.css';
 
 console.log(className); // .className_echwj_2
 ```
-Also, note that all your dashed class names will be transformed to camlCased one when it be individually imported, but the original will not be removed from the locals. For example:
+When `escapeDashes` is set to `true`, your dashed class names will be transformed to camelCased. For example:
 
 ```css
 .class-name {}
 ```
 ```js
 import style, { className } from './style.css';
-console.log(style['class-name'] === className) // true
+console.log(style.className === className) // true
 ```
 
 ### Extract CSS

--- a/test/build.js
+++ b/test/build.js
@@ -108,6 +108,93 @@ export function buildWithCssModules() {
   })
 }
 
+export function buildWithCssModulesEscapingDashes() {
+  const exportMap = {}
+  return rollup({
+    plugins: [
+      postcss({
+        include: '**/*.css',
+        sourceMap: true,
+        escapeDashes: true,
+        plugins: [
+          require('postcss-modules')({
+            getJSON(id, exportTokens) {
+              exportMap[id] = exportTokens
+            }
+          })
+        ],
+        getExport(id) {
+          return exportMap[id]
+        }
+      }),
+      babel({
+        babelrc: false,
+        presets: [['es2015', { modules: false }]],
+        include: '**/*.js',
+        sourceMap: true
+      })
+    ],
+    entry: path.resolve('./fixtures/fixture_modules.js')
+  }).then(bundle => {
+    const result = bundle.generate({
+      format: 'umd',
+      moduleName: 'default',
+      sourceMap: true
+    })
+    bundle.write({
+      dest: './output/output_modules.js',
+      moduleName: 'default',
+      format: 'umd',
+      sourceMap: true
+    })
+    return result.code
+  })
+}
+
+export function buildWithCssModulesEscapingDashesExportNamed() {
+  const exportMap = {}
+  return rollup({
+    plugins: [
+      postcss({
+        include: '**/*.css',
+        sourceMap: true,
+        escapeDashes: true,
+        exportNamed: true,
+        plugins: [
+          require('postcss-modules')({
+            getJSON(id, exportTokens) {
+              exportMap[id] = exportTokens
+            }
+          })
+        ],
+        getExport(id) {
+          return exportMap[id]
+        }
+      }),
+      babel({
+        babelrc: false,
+        presets: [['es2015', { modules: false }]],
+        include: '**/*.js',
+        sourceMap: true
+      })
+    ],
+    entry: path.resolve('./fixtures/fixture_modules.js')
+  }).then(bundle => {
+    const result = bundle.generate({
+      format: 'umd',
+      moduleName: 'default',
+      sourceMap: true
+    })
+    bundle.write({
+      dest: './output/output_modules.js',
+      moduleName: 'default',
+      format: 'umd',
+      sourceMap: true
+    })
+    return result.code
+  })
+}
+
 export function buildCombinedStyles() {
   const exportMap = {}
   return rollup({

--- a/test/fixtures/fixture_modules.js
+++ b/test/fixtures/fixture_modules.js
@@ -1,2 +1,2 @@
-import style, {fooBar, foo_bar} from './fixture_modules.css';
-export default {style, fooBar, foo_bar};
+import styleDefault, * as styleAll from './fixture_modules.css';
+export default {styleDefault, styleAll};

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,8 @@ import {
   buildDefault,
   buildWithParser,
   buildWithCssModules,
+  buildWithCssModulesEscapingDashes,
+  buildWithCssModulesEscapingDashesExportNamed,
   buildCombinedStyles,
   buildWithExtract,
   buildWithStylus
@@ -36,10 +38,27 @@ test('use sugarss as parser', async t => {
 test('use cssmodules', async t => {
   const data = await buildWithCssModules().catch(err => console.log(err.stack))
   const exported = requireFromString(data)
-  t.regex(exported.style.trendy, /trendy_/)
-  t.regex(exported.style.fooBar, /foo-bar_/)
-  t.regex(exported.fooBar, /foo-bar_/)
-  t.regex(exported.foo_bar, /foo_bar_/)
+  t.regex(exported.styleDefault.trendy, /trendy_/)
+  t.regex(exported.styleDefault['foo-bar'], /foo-bar_/)
+})
+
+test('use cssmodules with escaped dashes', async t => {
+  const data = await buildWithCssModulesEscapingDashes().catch(err =>
+    console.log(err.stack)
+  )
+  const exported = requireFromString(data)
+  t.regex(exported.styleDefault.trendy, /trendy_/)
+  t.regex(exported.styleDefault.fooBar, /foo-bar_/)
+})
+
+test('use cssmodules with escaped dashes and named exports', async t => {
+  const data = await buildWithCssModulesEscapingDashesExportNamed().catch(err =>
+    console.log(err.stack)
+  )
+  const exported = requireFromString(data)
+  t.regex(exported.styleDefault.trendy, /trendy_/)
+  t.regex(exported.styleDefault.fooBar, /foo-bar_/)
+  t.regex(exported.styleAll.fooBar, /foo-bar_/)
 })
 
 test('combine styles', async t => {


### PR DESCRIPTION
At least for me these are only troublesome. The automatic dash escaping for example fails completely when two consecutive dashes are in the name, like in many BEM style class names.This just makes the features optional, using new options `escapeDashes` and `exportNamed`