### PR TITLE
Emit `export var` instead of `export const`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ export default function(options = {}) {
                     let newKey = escapeClassNameDashes(key)
 
                     if (reserved.check(key)) newKey = `$${key}$`
-                    codeExportSparse += `export const ${newKey}=${JSON.stringify(
+                    codeExportSparse += `export var ${newKey}=${JSON.stringify(
                       codeExportDefault[key]
                     )};\n`
 


### PR DESCRIPTION
The code exported by this plugin is directly included in the code outputted by rollup. If this plugin is included in a project that targets ES5, using this plugin requires that project integrates babel into rollup in order to transform the `const` into `var`. In reality, since many projects do use Babel, this problem likely affects TypeScript projects, which don't necessarily use babel.

Would you be willing to consider changing the `const` to `var` so this plugin no longer requires babel?

Currently, I can easily work around this by including babel so it's not a big blocker, but I thought I'd at least ask. :)

To be clear, in my current project, I compile my TypeScript to JavaScript (instructing TypeScript to output ES6 module syntax), and then run Rollup against that JavaScript.