### PR TITLE
Fix issues with using postcss-import plugin and postcss-modules plugin

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -59,7 +59,7 @@ export default {
 
     const modulesExported = {}
     if (options.modules) {
-      plugins.unshift(
+      plugins.push(
         require('postcss-modules')({
           generateScopedName: '[name]_[local]__[hash:base64:5]',
           ...options.modules,


### PR DESCRIPTION
If you are using the [`postcss-import`](https://github.com/postcss/postcss-import) plugin, it requires that it be the first plugin passed to PostCSS ([See first note](https://github.com/postcss/postcss-import/blob/master/README.md) in the `postcss-import` README). Currently `rollup-plugin-postcss` puts the `postcss-modules` plugin first in the list of PostCSS plugins causing an issue if you use CSS Modules `composes` from an external file together with `@import` syntax from the `postcss-import` plugin. The issue is the data from `@import` gets wiped out by the inlining done by `composes` from `postcss-modules`. Example..
**Input**
```
// shared/border-radius.css
.all {
  border-radius: 3px;
}
```
```
// shared/colors.css
:root {
  --white: #fff;
}
```
```
// main.css
@import '../shared/colors.css';

.test {
  composes: all from '../shared/border-radius.css';
  background-color: var(--white);
}
```
**Output without this change**
```
.border-radius_all__3XQLI {
  border-radius: 3px;
}
.main_test__2schg {
  border-color: var(--white);
```

**Output with this change**
```
.border-radius_all__3XQLI {
  border-radius: 3px;
}

:root {
  --white: #fff;
}

.main_test__2schg {
  border-color: var(--white);
}
```

 This change makes it so that the `postcss-modules` plugin is last in the list of plugins passed to PostCSS.