### PR TITLE
Add localIdentName to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ Default: `false`
 
 Enable CSS modules or set options for `postcss-modules`.
 
+### localIdentName
+
+Type: `string` `function`<br>
+Default: `[name]_[local]__[hash:base64:5]`
+
+Configure the generated ident. More details in [here](https://github.com/css-modules/postcss-modules#generating-scoped-names)
+
 ### namedExports
 
 Type: `boolean` `function`<br>

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export default (options = {}) => {
     /** CSS modules */
     modules: inferOption(options.modules, false),
     namedExports: options.namedExports,
+    localIdentName: options.localIdentName,
     /** Options for cssnano */
     minimize: inferOption(options.minimize, false),
     /** Postcss config file */

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -64,7 +64,7 @@ export default {
     if (options.modules) {
       plugins.push(
         require('postcss-modules')({
-          generateScopedName: '[name]_[local]__[hash:base64:5]',
+          generateScopedName: options.localIdentName || '[name]_[local]__[hash:base64:5]',
           ...options.modules,
           getJSON(filepath, json) {
             modulesExported[filepath] = json

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -310,6 +310,22 @@ console.log(style.foo);
 "
 `;
 
+exports[`modules:local-ident-name: css code 1`] = `
+".GENERATED__style__foo {
+  color: red;
+}
+"
+`;
+
+exports[`modules:local-ident-name: js code 1`] = `
+"'use strict';
+
+var style = {\\"foo\\":\\"GENERATED__style__foo\\"};
+
+console.log(style.foo);
+"
+`;
+
 exports[`modules:named-exports: js code 1`] = `
 "'use strict';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -146,6 +146,16 @@ snapshot({
 })
 
 snapshot({
+  title: 'modules:local-ident-name',
+  input: 'css-modules/index.js',
+  options: {
+    localIdentName: 'GENERATED__[name]__[local]',
+    modules: true,
+    extract: true
+  }
+})
+
+snapshot({
   title: 'modules:extract',
   input: 'css-modules/index.js',
   options: {


### PR DESCRIPTION
This is PR to generate the custom classnames from css modules.

Useful when wanting to export deterministic and custom css classes.

More here: https://github.com/css-modules/postcss-modules#generating-scoped-names