### PR TITLE
Replace localRequire with the `import-cwd` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "concat-with-sourcemaps": "^1.0.5",
     "cssnano": "^3.10.0",
     "fs-extra": "^5.0.0",
+    "import-cwd": "^2.1.0",
     "pify": "^3.0.0",
     "postcss": "^6.0.1",
     "postcss-load-config": "^1.2.0",

--- a/src/less-loader.js
+++ b/src/less-loader.js
@@ -1,12 +1,12 @@
+import importCwd from 'import-cwd'
 import pify from 'pify'
 import humanlizePath from './utils/humanlize-path'
-import localRequire from './utils/local-require'
 
 export default {
   name: 'less',
   test: /\.less$/,
   async process({ code }) {
-    const less = localRequire('less')
+    const less = importCwd('less')
 
     let { css, map } = await pify(less.render.bind(less))(code, {
       ...this.options,

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -1,9 +1,9 @@
 import path from 'path'
+import importCwd from 'import-cwd'
 import postcss from 'postcss'
 import findPostcssConfig from 'postcss-load-config'
 import reserved from 'reserved-words'
 import humanlizePath from './utils/humanlize-path'
-import localRequire from './utils/local-require'
 import normalizePath from './utils/normalize-path'
 
 const styleInjectPath = require.resolve('style-inject/dist/style-inject.es').replace(/[\\/]+/g, '/')
@@ -45,7 +45,7 @@ function ensureClassName(name) {
 }
 
 function ensurePostCSSOption(option) {
-  return typeof option === 'string' ? localRequire(option) : option
+  return typeof option === 'string' ? importCwd(option) : option
 }
 
 export default {

--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import pify from 'pify'
 import resolve from 'resolve'
-import localRequire from './utils/local-require'
+import importCwd from 'import-cwd'
 
 const moduleRe = /^~([a-z0-9]|@).+/i
 
@@ -9,7 +9,7 @@ export default {
   name: 'sass',
   test: /\.s[ac]ss$/,
   async process({ code }) {
-    const sass = localRequire('node-sass')
+    const sass = importCwd('node-sass')
     const res = await pify(sass.render.bind(sass))({
       ...this.options,
       file: this.id,

--- a/src/stylus-loader.js
+++ b/src/stylus-loader.js
@@ -1,11 +1,11 @@
+import importCwd from 'import-cwd'
 import pify from 'pify'
-import localRequire from './utils/local-require'
 
 export default {
   name: 'stylus',
   test: /\.(styl|stylus)$/,
   async process({ code }) {
-    const stylus = localRequire('stylus')
+    const stylus = importCwd('stylus')
 
     const style = stylus(code, {
       ...this.options,

--- a/src/utils/local-require.js
+++ b/src/utils/local-require.js
@@ -1,5 +1,0 @@
-import path from 'path'
-
-const localRequire = name => require(path.resolve('node_modules', name))
-
-export default localRequire

--- a/yarn.lock
+++ b/yarn.lock
@@ -3051,6 +3051,18 @@ image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
 
+import-cwd@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
+  dependencies:
+    import-from "^2.1.0"
+
+import-from@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
+  dependencies:
+    resolve-from "^3.0.0"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -5378,6 +5390,10 @@ resolve-from@^1.0.0:
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
 resolve@1.1.7:
   version "1.1.7"


### PR DESCRIPTION
This package uses a more-accurate module resolution algorithm. It's basically just a wrapper around the `import-from` package @egoist suggested in #84, by the same author.