### PR TITLE
fix: handle importing Sass partials in node_modules

### DIFF
--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -10,6 +10,8 @@ const getUrlOfPartial = url => {
   return `${parsedUrl.dir}${path.sep}_${parsedUrl.base}`
 }
 
+const resolvePromise = pify(resolve)
+
 export default {
   name: 'sass',
   test: /\.s[ac]ss$/,
@@ -21,32 +23,43 @@ export default {
       data: code,
       indentedSyntax: /\.sass$/.test(this.id),
       sourceMap: this.sourceMap,
-      importer: [(url, importer, done) => {
-        if (!moduleRe.test(url)) return done({ file: url })
+      importer: [
+        (url, importer, done) => {
+          if (!moduleRe.test(url)) return done({ file: url })
 
-        const moduleUrl = url.slice(1)
-        const partialUrl = getUrlOfPartial(moduleUrl)
+          const moduleUrl = url.slice(1)
+          const partialUrl = getUrlOfPartial(moduleUrl)
 
-        const options = {
-          basedir: path.dirname(importer),
-          extensions: ['.scss', '.sass', '.css']
+          const options = {
+            basedir: path.dirname(importer),
+            extensions: ['.scss', '.sass', '.css']
+          }
+          const finishImport = id => {
+            done({
+              // Do not add `.css` extension in order to inline the file
+              file: id.endsWith('.css') ? id.replace(/\.css$/, '') : id
+            })
+          }
+
+          const next = () => {
+            // Catch all resolving errors, return the original file and pass responsibility back to other custom importers
+            done({ file: url })
+          }
+
+          // Give precedence to importing a partial
+          resolvePromise(partialUrl, options)
+            .then(finishImport)
+            .catch(err => {
+              if (err.code === 'MODULE_NOT_FOUND' || err.code === 'ENOENT') {
+                resolvePromise(moduleUrl, options)
+                  .then(finishImport)
+                  .catch(next)
+              } else {
+                next()
+              }
+            })
         }
-        const finishImport = id => {
-          done({
-            // Do not add `.css` extension in order to inline the file
-            file: id.endsWith('.css') ? id.replace(/\.css$/, '') : id
-          })
-
-          return id
-        }
-
-        // Give precedence to importing a partial
-        pify(resolve)(partialUrl, options)
-          .then(finishImport)
-          .catch(() => {
-            return pify(resolve)(moduleUrl, options).then(finishImport)
-          })
-      }].concat(this.options.importer || [])
+      ].concat(this.options.importer || [])
     })
 
     return {

--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -5,6 +5,11 @@ import importCwd from 'import-cwd'
 
 const moduleRe = /^~([a-z0-9]|@).+/i
 
+const getUrlOfPartial = url => {
+  const parsedUrl = path.parse(url)
+  return `${parsedUrl.dir}${path.sep}_${parsedUrl.base}`
+}
+
 export default {
   name: 'sass',
   test: /\.s[ac]ss$/,
@@ -19,18 +24,28 @@ export default {
       importer: [(url, importer, done) => {
         if (!moduleRe.test(url)) return done({ file: url })
 
-        resolve(url.slice(1), {
+        const moduleUrl = url.slice(1)
+        const partialUrl = getUrlOfPartial(moduleUrl)
+
+        const options = {
           basedir: path.dirname(importer),
           extensions: ['.scss', '.sass', '.css']
-        }, (err, id) => {
-          if (err) {
-            return Promise.reject(err)
-          }
+        }
+        const finishImport = id => {
           done({
             // Do not add `.css` extension in order to inline the file
             file: id.endsWith('.css') ? id.replace(/\.css$/, '') : id
           })
-        })
+
+          return id
+        }
+
+        // Give precedence to importing a partial
+        pify(resolve)(partialUrl, options)
+          .then(finishImport)
+          .catch(() => {
+            return pify(resolve)(moduleUrl, options).then(finishImport)
+          })
       }].concat(this.options.importer || [])
     })
 

--- a/test/fixtures/sass-import/_partial.scss
+++ b/test/fixtures/sass-import/_partial.scss
@@ -1,0 +1,1 @@
+$color: magenta;

--- a/test/fixtures/sass-import/foo.scss
+++ b/test/fixtures/sass-import/foo.scss
@@ -1,3 +1,5 @@
+@import "partial";
+
 .foo {
-  color: magenta;
+  color: $color;
 }

--- a/test/fixtures/sass-import/node_modules/foo/bar/_partial.scss
+++ b/test/fixtures/sass-import/node_modules/foo/bar/_partial.scss
@@ -1,0 +1,1 @@
+$color: magenta

--- a/test/fixtures/sass-import/style.scss
+++ b/test/fixtures/sass-import/style.scss
@@ -1,4 +1,5 @@
 @import "~foo/bar/a";
 @import "~foo/bar/b";
 @import "~foo/bar/c";
+@import "~foo/bar/partial";
 @import "foo.scss";


### PR DESCRIPTION
This fixes #86 by handling importing Sass partials from node_modules, so that something like this will work properly: `@import ~foo/bar/partial` where "partial" has the filename "_partial.scss".