### PR TITLE
upgrade: options.extract add new type: function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,8 @@ export default (options = {}) => {
         if (!filepath) {
           if (typeof postcssLoaderOptions.extract === 'string') {
             filepath = postcssLoaderOptions.extract
+          } else if (typeof postcssLoaderOptions.extract === "function") {
+            filepath = postcssLoaderOptions.extract(opts.file);
           } else {
             const basename = path.basename(opts.file, path.extname(opts.file))
             filepath = path.join(path.dirname(opts.file), basename + '.css')


### PR DESCRIPTION
sometimes output is a array, e.g:
```javascript
output: [
            {
                file: `lib/${fileName}`,
                format: 'cjs',
                sourcemap: true
            },
            {
                file: `es/${fileName}`,
                format: 'es',
                sourcemap: true
            }
],
```
then what I expect is:
```javascript
postcss({
                extract: outputPath => {
                    const filePath = path.join(path.dirname(outputPath), 'style', `${folderName}.css`);

                    return filePath;
                }
 })
```