### PR TITLE
Exposed the getJSON option for postcss-modules

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -85,6 +85,9 @@ export default {
             '[name]_[local]__[hash:base64:5]',
           ...options.modules,
           getJSON(filepath, json) {
+            if (typeof options.modules.getJSON === 'function') {
+              json = options.modules.getJSON(filepath, json);
+            }
             modulesExported[filepath] = json
           }
         })

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -86,7 +86,7 @@ export default {
           ...options.modules,
           getJSON(filepath, json) {
             if (typeof options.modules.getJSON === 'function') {
-              json = options.modules.getJSON(filepath, json);
+              json = options.modules.getJSON(filepath, json)
             }
             modulesExported[filepath] = json
           }


### PR DESCRIPTION
For using this module in conjunction with typescript, i needed a way to convert the json keys to camelcase.
Unfortunately, the method getJSON it's not directly accessible. 

So instead, if this option is set, I call it in your getJSON function and replace the JSON object directly.

I hope this solution is not to hacky, to be part of your module.