### PR TITLE
Sort extracted styles according to module order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ export default (options = {}) => {
       }
     },
 
-    async onwrite(opts) {
+    async onwrite(opts, bundle) {
       if (extracted.size === 0) return
 
       const getExtracted = filepath => {
@@ -143,7 +143,16 @@ export default (options = {}) => {
         }
         filepath = humanlizePath(filepath)
         const concat = new Concat(true, filepath, '\n')
-        for (const res of extracted.values()) {
+        const entries = [...extracted.entries()]
+
+        if (bundle.modules) {
+          entries.sort((a, b) => (
+            bundle.modules.indexOf(a[0]) - bundle.modules.indexOf(b[0])
+          ))
+        }
+
+        // eslint-disable-next-line no-unused-vars
+        for (const [_, res] of entries) {
           const relative = humanlizePath(res.id)
           const map = res.map || null
           if (map) {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -487,8 +487,12 @@ console.log(
 `;
 
 exports[`modules extract: css code 1`] = `
-".style_foo {
+".bar_shouldBeOverridden {
   color: red;
+}
+
+.style_shouldOverride {
+  color: green;
 }
 "
 `;
@@ -496,9 +500,12 @@ exports[`modules extract: css code 1`] = `
 exports[`modules extract: js code 1`] = `
 "'use strict';
 
-var style = {\\"foo\\":\\"style_foo\\"};
+var css = {\\"shouldBeOverridden\\":\\"bar_shouldBeOverridden\\"};
 
-console.log(style.foo);
+var second = {\\"shouldOverride\\":\\"style_shouldOverride\\"};
+
+console.log(\\"first\\", css.shouldBeOverridden);
+console.log(\\"second\\", second.shouldOverride);
 "
 `;
 
@@ -532,11 +539,16 @@ function styleInject(css, ref) {
   }
 }
 
-var css = \\".style_foo {\\\\n  color: red;\\\\n}\\\\n\\";
-var style = {\\"foo\\":\\"style_foo\\"};
+var css = \\".bar_shouldBeOverridden {\\\\n  color: red;\\\\n}\\\\n\\";
+var css$1 = {\\"shouldBeOverridden\\":\\"bar_shouldBeOverridden\\"};
 styleInject(css);
 
-console.log(style.foo);
+var css$2 = \\".style_shouldOverride {\\\\n  color: green;\\\\n}\\\\n\\";
+var second = {\\"shouldOverride\\":\\"style_shouldOverride\\"};
+styleInject(css$2);
+
+console.log(\\"first\\", css$1.shouldBeOverridden);
+console.log(\\"second\\", second.shouldOverride);
 "
 `;
 

--- a/test/fixtures/css-modules/bar/bar.css
+++ b/test/fixtures/css-modules/bar/bar.css
@@ -1,0 +1,3 @@
+.shouldBeOverridden {
+  color: red;
+}

--- a/test/fixtures/css-modules/bar/index.js
+++ b/test/fixtures/css-modules/bar/index.js
@@ -1,0 +1,2 @@
+import css from "./bar.css"
+export default css

--- a/test/fixtures/css-modules/index.js
+++ b/test/fixtures/css-modules/index.js
@@ -1,3 +1,5 @@
-import style from './style.css'
+import first from "./bar/index.js"
+import second from './style.css'
 
-console.log(style.foo)
+console.log("first", first.shouldBeOverridden)
+console.log("second", second.shouldOverride)

--- a/test/fixtures/css-modules/style.css
+++ b/test/fixtures/css-modules/style.css
@@ -1,3 +1,3 @@
-.foo {
-  color: red;
+.shouldOverride {
+  color: green;
 }


### PR DESCRIPTION
Heavily guided by the reference-implementation by [danburzo](https://github.com/danburzo) in https://github.com/egoist/rollup-plugin-postcss/issues/96 these changes correct the source ordering of the extracted styles in the [minimal example](https://github.com/dnjstrom/extract-css-source-order) from https://github.com/egoist/rollup-plugin-postcss/issues/108 and my original project.