### PR TITLE
Allow users to set the getJSON option

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -84,8 +84,12 @@ export default {
             '[name]_[local]' :
             '[name]_[local]__[hash:base64:5]',
           ...options.modules,
-          getJSON(filepath, json) {
+          getJSON(filepath, json, outfilepath) {
             modulesExported[filepath] = json
+            if (options.modules && options.modules.getJSON) {
+              // return because getJSON may be a Promise
+              return options.modules.getJSON(filepath, json, outfilepath)
+            }
           }
         })
       )


### PR DESCRIPTION
instead of silently overriding it