### PR TITLE
Allow to pass options to built-in loaders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export default (options = {}) => {
       exec: options.exec
     }
   }
-  const use = options.use || ['sass', 'stylus', 'less']
+  const use = options.use || [['sass', options.sass || {}], ['stylus', options.stylus || {}], ['less', options.less || {}]]
   use.unshift(['postcss', postcssLoaderOptions])
 
   const loaders = new Loaders({


### PR DESCRIPTION
I wanted to pass options to `node-sass`. It looks like the only solution I have is to copy/paste your sassLoader to be able to register it with options.

So I added a bit of API to pass some options to built-in loaders