### PR TITLE
Allow custom `modules.getJSON` function

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -87,7 +87,7 @@ export default {
           getJSON(filepath, json, outpath) {
             modulesExported[filepath] = json
             if (typeof options.modules === 'object' && typeof options.modules.getJSON === 'function') {
-              options.modules.getJSON(filepath, json, outpath)
+              return options.modules.getJSON(filepath, json, outpath)
             }
           }
         })

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -84,8 +84,11 @@ export default {
             '[name]_[local]' :
             '[name]_[local]__[hash:base64:5]',
           ...options.modules,
-          getJSON(filepath, json) {
+          getJSON(filepath, json, outpath) {
             modulesExported[filepath] = json
+            if (typeof options.modules === 'object' && typeof options.modules.getJSON === 'function') {
+              options.modules.getJSON(filepath, json, outpath)
+            }
           }
         })
       )

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -540,6 +540,44 @@ console.log(style.foo);
 "
 `;
 
+exports[`modules inject-object: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\".style_foo {\\\\n  color: red;\\\\n}\\\\n\\";
+var style = {\\"foo\\":\\"style_foo\\"};
+styleInject(css);
+
+console.log(style.foo);
+"
+`;
+
 exports[`modules named-exports: js code 1`] = `
 "'use strict';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -164,6 +164,17 @@ snapshotMany('modules', [
     }
   },
   {
+    title: 'inject-object',
+    input: 'css-modules/index.js',
+    options: {
+      modules: {
+        getJSON() {
+          //
+        }
+      }
+    }
+  },
+  {
     title: 'named-exports',
     input: 'named-exports/index.js',
     options: {


### PR DESCRIPTION
Hey~!

As of now, there's no way to access the JSON file of classnames to their outputs. It can only happen thru the [`getJSON` method of `postcss-modules`](https://github.com/css-modules/postcss-modules#saving-exported-classes), but it's overridden here.

This PR allows a user to define a custom `getJSON` method, passing it all arguments for them to do as they please. It does not affect the core behavior of the plugin.

---

_Also closes #101_