### PR TITLE
Chore: Upgrade cssnano

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@vue/component-compiler-utils": "^1.0.0",
     "chalk": "^2.0.0",
     "concat-with-sourcemaps": "^1.0.5",
-    "cssnano": "^3.10.0",
+    "cssnano": "^4.1.5",
     "fs-extra": "^5.0.0",
     "import-cwd": "^2.1.0",
     "p-queue": "^2.4.2",


### PR DESCRIPTION
This is a fairly big upgrade and should be done asap imo. Most notably, `cssnano@4` runs on the latest Browserslist, which supports the `dead` query. Babel@7 also runs on this version of Browserslist, so until this dependency gets updated, a single `"browserslist"` config will be incompatible between tools.

---

_Closes #121_