### PR TITLE
Support custom getJSON handler in modules config

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -85,6 +85,8 @@ export default {
           ...options.modules,
           getJSON(filepath, json) {
             modulesExported[filepath] = json
+            // Execute custom getJSON if provided in config
+            options.modules.getJSON && options.modules.getJSON(filepath, json)
           }
         })
       )


### PR DESCRIPTION
I was passing in a getJSON which wasn't being executed, turns out it was being overwritten by this plugin. This fix makes sure it's called properly.