### PR TITLE
Allow boolean plugins support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function inferOption(option, defaultValue) {
 
 export default (options = {}) => {
   const filter = createFilter(options.include, options.exclude)
-  const plugins = Array.isArray(options.plugins) ? options.plugins.filter(Boolean) : options.plugins
+  const postcssPlugins = Array.isArray(options.plugins) ? options.plugins.filter(Boolean) : options.plugins
   const sourceMap = options.sourceMap
   const postcssLoaderOptions = {
     /** Inject CSS as `<style>` to `<head>` */
@@ -37,7 +37,7 @@ export default (options = {}) => {
     /** PostCSS options */
     postcss: {
       parser: options.parser,
-      plugins: plugins,
+      plugins: postcssPlugins,
       syntax: options.syntax,
       stringifier: options.stringifier,
       exec: options.exec

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ function inferOption(option, defaultValue) {
 
 export default (options = {}) => {
   const filter = createFilter(options.include, options.exclude)
+  const plugins = Array.isArray(options.plugins) ? options.plugins.filter(Boolean) : options.plugins
   const sourceMap = options.sourceMap
   const postcssLoaderOptions = {
     /** Inject CSS as `<style>` to `<head>` */
@@ -36,7 +37,7 @@ export default (options = {}) => {
     /** PostCSS options */
     postcss: {
       parser: options.parser,
-      plugins: options.plugins.filter(Boolean),
+      plugins: plugins,
       syntax: options.syntax,
       stringifier: options.stringifier,
       exec: options.exec

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ export default (options = {}) => {
     /** PostCSS options */
     postcss: {
       parser: options.parser,
-      plugins: options.plugins,
+      plugins: options.plugins.filter(Boolean),
       syntax: options.syntax,
       stringifier: options.stringifier,
       exec: options.exec


### PR DESCRIPTION
Allow boolean plugins similar to how Rollup plugins work. In the Rollup plugins array you may write the following to only run a plugin for production usage:

```js
plugins: [
  (process.env.NODE_ENV === 'production' && terser())
]
```

This pull request allow the same approach for PostCSS plugins:

```js
plugins: [
  (process.env.NODE_ENV === 'production' && cssnano())
]
```

[Example of how Rollup has implemented this feature.](https://github.com/rollup/rollup/blob/f58d1e60a3da4b8470e5d56aa0caef2ecadec2b8/src/rollup/index.ts#L107)