### PR TITLE
Added sass file watching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,10 @@ export default (options = {}) => {
         sourceMap
       })
 
+      if (res.dependencies) {
+        res.dependencies.forEach(dependency => this.addWatchFile(dependency))
+      }
+
       if (postcssLoaderOptions.extract) {
         extracted.set(id, res.extracted)
         return {

--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -72,6 +72,7 @@ export default {
         }).then(res =>
           resolve({
             code: res.css.toString(),
+            dependencies: res.stats.includedFiles,
             map: res.map && res.map.toString()
           })
         ).catch(reject)


### PR DESCRIPTION
**Note:** This pull request is still work in progress.

This PR adds support for imported Sass file watching using Rollup's new `addWatchFile` function. I'm currently stuck and in need of guidance. I'm getting the following error:

```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'options' of undefined
```

I find this strange since it should be caught here:

https://github.com/egoist/rollup-plugin-postcss/blob/20aeab4668492897ea657990e77a1b420e024f17/src/sass-loader.js#L77

This is the line where the error occurs:

https://github.com/egoist/rollup-plugin-postcss/blob/20aeab4668492897ea657990e77a1b420e024f17/src/sass-loader.js#L30

Any ideas how I can get this to work and fix/prevent the error message?

