### PR TITLE
Pass the `extract` option to postcss

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -106,7 +106,7 @@ export default {
       ...config.options,
       // Followings are never modified by user config config
       from: this.id,
-      to: this.id,
+      to: typeof shouldExtract === 'string' ? shouldExtract : this.id,
       map: this.sourceMap ?
         shouldExtract ?
           { inline: false, annotation: false } :

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -186,7 +186,7 @@ body {
 /*# sourceMappingURL=this/is/extracted.css.map */"
 `;
 
-exports[`extract custom-path: css map 1`] = `"{\\"version\\":3,\\"sources\\":[\\"foo.css\\",\\"bar.css\\",\\"test/fixtures/simple/style.styl\\",\\"style.styl\\",\\"style.sass\\",\\"test/fixtures/simple/style.less\\",\\"style.less\\",\\"style.pcss\\"],\\"names\\":[],\\"mappings\\":\\"AAAA;EACE,UAAU;AACZ;;ACFA;EACE,UAAU;AACZ;;ACFA;EACE,WAAO;EACP,gBAAY;ACCd;AACA,yDAAyD;ACJzD;EACE,UAAU;EACV,sBAAsB,EAAE;;ACC1B;EACE,cAAA;ACFF;;ACFA;EACE,UAAU;AACZ\\",\\"file\\":\\"this/is/extracted.css\\",\\"sourcesContent\\":[\\"body {\\\\n  color: red;\\\\n}\\\\n\\",\\".bar {\\\\n  color: red;\\\\n}\\\\n\\",null,null,\\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa; }\\\\n\\",null,null,\\".pcss {\\\\n  color: red;\\\\n}\\\\n\\"]}"`;
+exports[`extract custom-path: css map 1`] = `"{\\"version\\":3,\\"sources\\":[\\"../../../../simple/foo.css\\",\\"../../../../simple/bar.css\\",\\"../../../../simple/test/fixtures/simple/style.styl\\",\\"../../../../simple/style.styl\\",\\"../../../../simple/style.sass\\",\\"../../../../simple/test/fixtures/simple/style.less\\",\\"../../../../simple/style.less\\",\\"../../../../simple/style.pcss\\"],\\"names\\":[],\\"mappings\\":\\"AAAA;EACE,UAAU;AACZ;;ACFA;EACE,UAAU;AACZ;;ACFA;EACE,WAAO;EACP,gBAAY;ACCd;AACA,yDAAyD;ACJzD;EACE,UAAU;EACV,sBAAsB,EAAE;;ACC1B;EACE,cAAA;ACFF;;ACFA;EACE,UAAU;AACZ\\",\\"file\\":\\"this/is/extracted.css\\",\\"sourcesContent\\":[\\"body {\\\\n  color: red;\\\\n}\\\\n\\",\\".bar {\\\\n  color: red;\\\\n}\\\\n\\",null,null,\\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa; }\\\\n\\",null,null,\\".pcss {\\\\n  color: red;\\\\n}\\\\n\\"]}"`;
 
 exports[`extract custom-path: js code 1`] = `
 "'use strict';


### PR DESCRIPTION
When extracting assets by using plugin such as [postcss-url](https://github.com/postcss/postcss-url), option `to` is used to rebase the assets, so it should be exactly the same with option `extract` when `extract` is provided.

Actually I would like to also make option `to` proper when `extract` is `true`, but unfortunately `output` options are not shared to plugin's [`transform`](https://rollupjs.org/guide/en#transform) hook.