### PR TITLE
Added embedSources option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ Type: `boolean` `"inline"`
 
 Enable sourceMap.
 
+### embedSources
+
+Type: `boolean` `Object`
+
+Embed source contents into source map data.
+
+```javascript
+...
+embedSources: true
+...
+```
+
+An object with rootPath option can be passed to specify base dir.
+
+```javascript
+...
+embedSources: {
+  rootPath: path.resolve('..');
+}
+...
+```
+
 ### parser
 
 Type: `string` `function`

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs'
 import { createFilter } from 'rollup-pluginutils'
 import Concat from 'concat-with-sourcemaps'
 import Loaders from './loaders'
@@ -130,7 +131,16 @@ export default (options = {}) => {
           const relative = path.relative(dir, res.id)
           const map = res.map || null
           if (map) {
-            map.file = fileName
+            map.file = fileName;
+
+            if (options.embedSources) {
+              let rootPath = options.embedSources.rootPath || '.';
+              map.sourcesContent = map.sources.map((source, idx) => {
+                const file = idx == 0 ? res.id : source.replace(/^file\:\/\//, '');
+                map.sources[idx] = path.relative(rootPath, file);
+                return fs.readFileSync(file, 'utf8');
+              });
+            }
           }
           concat.add(relative, res.code, map)
         }


### PR DESCRIPTION
Sourcemap does not add embed source contents and reference the local files instead. This may be a problem on remote debugging as the debugger will not have access to the local files.

I'm not sure there is a way to embed source files in the map data by configuring the options but since I couldn't find, I added a couple of lines to make it. 

If you find it useful, feel free to pull my changes.

Before:
![image](https://user-images.githubusercontent.com/813743/52273966-67665300-295c-11e9-9bc7-ac3d464f69f1.png)



After:
![image](https://user-images.githubusercontent.com/813743/52274023-8bc22f80-295c-11e9-976a-e8131459ec4d.png)

