### PR TITLE
Added support for PostCSS "to" option for some plugins that are relying on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ module.exports = context => {
 }
 ```
 
+### to
+
+Type: `string`
+
+Destination CSS filename hint that could be used by PostCSS plugins, for example, 
+to properly resolve path, rebase and copy assets.
+
 ### use
 
 Type: `name[]` `[name, options][]`<br>

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ export default (options = {}) => {
     minimize: inferOption(options.minimize, false),
     /** Postcss config file */
     config: inferOption(options.config, {}),
+    /** PostCSS target filename hint, for plugins that are relying on it */
+    to: options.to,
     /** PostCSS options */
     postcss: {
       parser: options.parser,

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -104,9 +104,10 @@ export default {
     const postcssOpts = {
       ...this.options.postcss,
       ...config.options,
+      // Allow overriding `to` for some plugins that are relying on this value
+      to: options.to || this.id,
       // Followings are never modified by user config config
       from: this.id,
-      to: this.id,
       map: this.sourceMap ?
         shouldExtract ?
           { inline: false, annotation: false } :


### PR DESCRIPTION
Added support for PostCSS to option for some plugins that are relying on it

Fixes #145

Almost all PostCSS asset rebase plugins are relying on `to` options to properly rebase path and with hardcoded value for `to` they just don't work. This PR addresses this issue and adds `to` option that could be explicitly set if it is needed.