### PR TITLE
prepend scss with data property

### DIFF
--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -25,14 +25,17 @@ export default {
     return new Promise((resolve, reject) => {
       const sass = importCwd.silent('node-sass') || importCwd.silent('sass')
       if (!sass) {
-        throw new Error(`You need to install either node-sass or sass in order to process Sass files`)
+        throw new Error(
+          `You need to install either node-sass or sass in order to process Sass files`
+        )
       }
       const render = pify(sass.render.bind(sass))
+      const data = this.options.data || ''
       return workQueue.add(() =>
         render({
           ...this.options,
           file: this.id,
-          data: code,
+          data: data + code,
           indentedSyntax: /\.sass$/.test(this.id),
           sourceMap: this.sourceMap,
           importer: [


### PR DESCRIPTION
The `data` option in the SASS preprocessor prevented the contents of the file.
I made a quick edit so now, the data attribute in the options is composed of the passed options and the file content.