### PR TITLE
Fix sass-loader not calling user-defined importers

### DIFF
--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -37,7 +37,7 @@ export default {
           sourceMap: this.sourceMap,
           importer: [
             (url, importer, done) => {
-              if (!moduleRe.test(url)) return done({ file: url })
+              if (!moduleRe.test(url)) return null
 
               const moduleUrl = url.slice(1)
               const partialUrl = getUrlOfPartial(moduleUrl)
@@ -54,8 +54,8 @@ export default {
               }
 
               const next = () => {
-                // Catch all resolving errors, return the original file and pass responsibility back to other custom importers
-                done({ file: url })
+                // Catch all resolving errors, return null to pass responsibility back to other custom importers
+                done(null)
               }
 
               // Give precedence to importing a partial


### PR DESCRIPTION
As per [sass's `import` documentation](https://github.com/sass/node-sass#importer--v200---experimental), in order to pass the responsibility of a file down the pipe, you must return null.

Currently, `sass-loader` is calling `done({ file: string })`, telling LibSass an alternate path to use.

The proposed solution fixes this issue (I came to it while trying to import a JSON file with [node-sass-json-importer](https://github.com/Updater/node-sass-json-importer))