### PR TITLE
Fixed importers behaviour for sass-loader

### DIFF
--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -55,7 +55,7 @@ export default {
 
               const next = () => {
                 // Catch all resolving errors, return the original file and pass responsibility back to other custom importers
-                done({ file: url })
+                return null
               }
 
               // Give precedence to importing a partial


### PR DESCRIPTION
Accroding to node-sass docs: https://github.com/sass/node-sass#importer--v200---experimental

> importer can be an array of functions, which will be called by LibSass in the order of their occurrence in array. This helps user specify special importer for particular kind of path (filesystem, http). If an importer does not want to handle a particular path, it should return `null`