### PR TITLE
feat: implemented more robust module loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-/node_modules
-dist
-coverage
+/**/dist/
+/.idea/
+/coverage/
+/node_modules/
+/package-lock.json

--- a/src/less-loader.js
+++ b/src/less-loader.js
@@ -1,12 +1,15 @@
-import importCwd from 'import-cwd'
 import pify from 'pify'
 import humanlizePath from './utils/humanlize-path'
+import { loadModule } from './utils/load-module'
 
 export default {
   name: 'less',
   test: /\.less$/,
   async process({ code }) {
-    const less = importCwd('less')
+    const less = loadModule('less')
+    if (!less) {
+      throw new Error(`You need to install "less" packages in order to process Less files`)
+    }
 
     let { css, map, imports } = await pify(less.render.bind(less))(code, {
       ...this.options,

--- a/src/stylus-loader.js
+++ b/src/stylus-loader.js
@@ -1,11 +1,14 @@
-import importCwd from 'import-cwd'
 import pify from 'pify'
+import { loadModule } from './utils/load-module'
 
 export default {
   name: 'stylus',
   test: /\.(styl|stylus)$/,
   async process({ code }) {
-    const stylus = importCwd('stylus')
+    const stylus = loadModule('stylus')
+    if (!stylus) {
+      throw new Error(`You need to install "stylus" packages in order to process Stylus files`)
+    }
 
     const style = stylus(code, {
       ...this.options,

--- a/src/utils/load-module.js
+++ b/src/utils/load-module.js
@@ -1,0 +1,12 @@
+import importCwd from 'import-cwd'
+
+export function loadModule(moduleId) {
+  // Trying to load module normally (relative to plugin directory)
+  const path = require.resolve(moduleId)
+  if (path) {
+    return require(path)
+  }
+
+  // Then, trying to load it relative to CWD
+  return importCwd.silent(moduleId)
+}


### PR DESCRIPTION
Hello!

Right now `rollup-plugin-postcss` loads dependencies like `node-sass` using `import-cwd` utility, which searches for modules strictly in the current working directory of the executing script. In the general use case this could be working correctly, however, if you have a more non-trivial setup or you are not running Rollup in the expected directory this will lead to modules not being found.

Also, this approach doesn't respect [Node Module Resolution Algorithm](https://nodejs.org/api/modules.html#modules_all_together) at full, e.g. it completely ignores the `NODE_PATH` environment variable.

This PR fixes these issues by implementing two-step loading mechanism, first, it tries to load the requested module normally using conventional resolution algorithm and then it falls back to loading from CWD (as it was working before). This should fix the aforementioned issues and maintain the backward compatibility.

Linting rules are respected, all test are green.

This should be released as the MINOR version update according to semver.

We would really appreciate if it could be merged and released ASAP as it's blocking development of our corporate CLI tool. Thank you!

---

Commit message:

- added loadModule() utility function
- updated loaders to use new module loading mechanism
- added more entries to gitignore file
- refactored gitignore to be more explicit