### PR TITLE
Added support for consuming stringfied bundle of the css code to be injected from JS.

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -186,7 +186,7 @@ export default {
     } else {
       output += `var css = ${JSON.stringify(res.css)};\nexport default ${
         supportModules ? JSON.stringify(modulesExported[this.id]) : 'css'
-      };`;
+      };`
       output += `\nexport const stylesheet=${JSON.stringify(res.css)};`;
     }
     if (!shouldExtract && shouldInject) {

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -186,7 +186,7 @@ export default {
     } else {
       output += `var css = ${JSON.stringify(res.css)};\nexport default ${
         supportModules ? JSON.stringify(modulesExported[this.id]) : 'css'
-      };\\nexport const stylesheet=${JSON.stringify(res.css)};`
+      };\nexport const stylesheet=${JSON.stringify(res.css)};`
     }
     if (!shouldExtract && shouldInject) {
       output += `\nimport styleInject from '${styleInjectPath}';\nstyleInject(css${

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -186,7 +186,7 @@ export default {
     } else {
       output += `var css = ${JSON.stringify(res.css)};\nexport default ${
         supportModules ? JSON.stringify(modulesExported[this.id]) : 'css'
-      };`
+      };`;
       output += `\nexport const stylesheet=${JSON.stringify(res.css)};`;
     }
     if (!shouldExtract && shouldInject) {

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -186,8 +186,7 @@ export default {
     } else {
       output += `var css = ${JSON.stringify(res.css)};\nexport default ${
         supportModules ? JSON.stringify(modulesExported[this.id]) : 'css'
-      };`
-      output += `\nexport const stylesheet=${JSON.stringify(res.css)};`;
+      };\\nexport const stylesheet=${JSON.stringify(res.css)};`
     }
     if (!shouldExtract && shouldInject) {
       output += `\nimport styleInject from '${styleInjectPath}';\nstyleInject(css${

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -187,6 +187,7 @@ export default {
       output += `var css = ${JSON.stringify(res.css)};\nexport default ${
         supportModules ? JSON.stringify(modulesExported[this.id]) : 'css'
       };`
+      output += `\nexport const stylesheet=${JSON.stringify(res.css)};`;
     }
     if (!shouldExtract && shouldInject) {
       output += `\nimport styleInject from '${styleInjectPath}';\nstyleInject(css${

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -631,12 +631,14 @@ var foo = \\"style_foo\\";
 var $new$ = \\"style_new\\";
 var css = \\".style_foo {\\\\n  color: red;\\\\n}\\\\n\\\\n.style_new {\\\\n  color: blue;\\\\n}\\\\n\\";
 var style = {\\"foo\\":\\"style_foo\\",\\"new\\":\\"style_new\\",\\"$new$\\":\\"style_new\\"};
+const stylesheet=\\".style_foo {\\\\n  color: red;\\\\n}\\\\n\\\\n.style_new {\\\\n  color: blue;\\\\n}\\\\n\\";
 styleInject(css);
 
 var style$1 = /*#__PURE__*/Object.freeze({
   foo: foo,
   $new$: $new$,
-  default: style
+  default: style,
+  stylesheet: stylesheet
 });
 
 console.log(style$1);
@@ -677,12 +679,14 @@ var foohacked = \\"style_foo\\";
 var newhacked = \\"style_new\\";
 var css = \\".style_foo {\\\\n  color: red;\\\\n}\\\\n\\\\n.style_new {\\\\n  color: blue;\\\\n}\\\\n\\";
 var style = {\\"foo\\":\\"style_foo\\",\\"new\\":\\"style_new\\",\\"foohacked\\":\\"style_foo\\",\\"newhacked\\":\\"style_new\\"};
+const stylesheet=\\".style_foo {\\\\n  color: red;\\\\n}\\\\n\\\\n.style_new {\\\\n  color: blue;\\\\n}\\\\n\\";
 styleInject(css);
 
 var style$1 = /*#__PURE__*/Object.freeze({
   foohacked: foohacked,
   newhacked: newhacked,
-  default: style
+  default: style,
+  stylesheet: stylesheet
 });
 
 console.log(style$1);


### PR DESCRIPTION
Added support for consuming stringfied bundle of the css code to be injected from JS.

Basically, when setting up the option 'extract' with this change we will have the capacity to inject anywhere the bundled css from straight from the JS without having to inject it in the .
image. 

The stringfied bundled css will be exported as a const named `stylesheet`

![1](https://user-images.githubusercontent.com/4801218/74609741-2c5d3a80-50ed-11ea-8c26-47d61d76e53c.png)

This poses a great advantage in terms of confectioning your own web components with CSS modules and injecting the styles in a custom <style> tag at the coder's discretion.

![2](https://user-images.githubusercontent.com/4801218/74609747-37b06600-50ed-11ea-86f2-26787b7a9735.png)

Here is a screenshot of the overall result.
![3](https://user-images.githubusercontent.com/4801218/74609751-4008a100-50ed-11ea-939c-31d4f928521c.png)

Please feel free to reach me to discuss it any further.