### PR TITLE
[sass-loader] Prepend options.data to code payload

### DIFF
--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -28,11 +28,12 @@ export default {
     return new Promise((resolve, reject) => {
       const sass = loadSassOrThrow()
       const render = pify(sass.render.bind(sass))
+      const data = this.options.data || ''
       return workQueue.add(() =>
         render({
           ...this.options,
           file: this.id,
-          data: code,
+          data: data + code,
           indentedSyntax: /\.sass$/.test(this.id),
           sourceMap: this.sourceMap,
           importer: [

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -696,6 +696,41 @@ console.log(undefined, undefined);
 "
 `;
 
+exports[`sass data-prepend: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\".special {\\\\n  color: pink; }\\\\n\\";
+styleInject(css);
+"
+`;
+
 exports[`sass default: js code 1`] = `
 "'use strict';
 

--- a/test/fixtures/sass-data-prepend/_prepend.scss
+++ b/test/fixtures/sass-data-prepend/_prepend.scss
@@ -1,0 +1,1 @@
+$special-color: pink;

--- a/test/fixtures/sass-data-prepend/index.js
+++ b/test/fixtures/sass-data-prepend/index.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/test/fixtures/sass-data-prepend/style.scss
+++ b/test/fixtures/sass-data-prepend/style.scss
@@ -1,0 +1,3 @@
+.special {
+  color: $special-color;
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,6 +315,18 @@ snapshotMany('sass', [
     }
   },
   {
+    title: 'data-prepend',
+    input: 'sass-data-prepend/index.js',
+    options: {
+      use: [
+        [
+          'sass',
+          { data: '@import \'prepend\';' }
+        ]
+      ]
+    }
+  },
+  {
     title: 'import',
     input: 'sass-import/index.js'
   }


### PR DESCRIPTION
> Originally by @bastienrobert on #179 (currently has conflicts). I'm hoping this new PR will be friendlier to merge.

Adds `data` prepend feature common on sass-loader implementations.

**Example:** https://github.com/differui/rollup-plugin-sass#options-1

cc @cortopy @egoist 
