### PR TITLE
Use this.emitFile for emitting files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,17 +206,17 @@ export default (options = {}) => {
 
       const codeFile = {
         fileName: codeFileName,
-        isAsset: true,
+        type: 'asset',
         source: code
       }
-      bundle[codeFile.fileName] = codeFile
+      this.emitFile(codeFile)
       if (map) {
         const mapFile = {
           fileName: mapFileName,
-          isAsset: true,
+          type: 'asset',
           source: map
         }
-        bundle[mapFile.fileName] = mapFile
+        this.emitFile(mapFile)
       }
     }
   }


### PR DESCRIPTION
This pull request fixes the following warning that occurs in Rollup 2.x:
>(!) A plugin is directly adding properties to the bundle object in the "generateBundle" hook. This is deprecated and will be removed in a future Rollup version, please use "this.emitFile" instead.