### PR TITLE
Place postcss-modules plugin first

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -72,7 +72,7 @@ export default {
     const autoModules = options.autoModules !== false && isModuleFile(this.id)
     const supportModules = options.modules || autoModules
     if (supportModules) {
-      plugins.push(
+      plugins.unshift(
         require('postcss-modules')({
           // In tests
           // Skip hash in names since css content on windows and linux would differ because of `new line` (\r?\n)


### PR DESCRIPTION
Fixes #70 

If the postcss-modules plugin isn't placed first we end up with non-modularized rules along with modularized rules. This situation thus leads to heavier bundles due to code duplication that end up dead and, when the extract option is set to false, it can cause conflicts with other non-modularized (global) rules present in the bundle consumer code.