### PR TITLE
Fix using multiple postcss() plugin instances

### DIFF
--- a/src/loaders.js
+++ b/src/loaders.js
@@ -28,7 +28,7 @@ export default class Loaders {
     const extensions = options.extensions || ['.css', '.sss', '.pcss']
     const customPostcssLoader = {
       ...postcssLoader,
-      test: extensions.some(ext => path.extname(filepath) === ext)
+      test: filepath => extensions.some(ext => path.extname(filepath) === ext)
     } 
     this.registerLoader(customPostcssLoader)
     this.registerLoader(sassLoader)

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -26,9 +26,11 @@ export default class Loaders {
     this.loaders = []
 
     const extensions = options.extensions || ['.css', '.sss', '.pcss']
-    postcssLoader.test = filepath =>
-      extensions.some(ext => path.extname(filepath) === ext)
-    this.registerLoader(postcssLoader)
+    const customPostcssLoader = {
+      ...postcssLoader,
+      test: extensions.some(ext => path.extname(filepath) === ext)
+    } 
+    this.registerLoader(customPostcssLoader)
     this.registerLoader(sassLoader)
     this.registerLoader(stylusLoader)
     this.registerLoader(lessLoader)

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -29,7 +29,7 @@ export default class Loaders {
     const customPostcssLoader = {
       ...postcssLoader,
       test: filepath => extensions.some(ext => path.extname(filepath) === ext)
-    } 
+    }
     this.registerLoader(customPostcssLoader)
     this.registerLoader(sassLoader)
     this.registerLoader(stylusLoader)


### PR DESCRIPTION
Setting the test on the loader itself means that a second instance of the plugin would override the previous test.

My config looks like this fwiw:
```js
export default () => {
  return {
    input: {},
    output: {},
    plugins: [
      // ...
      postcss({
        extensions: ['.css'],
        include: ['**/*.css'],
        use: []
      }),
      postcss({
        extensions: ['.less'],
        include: ['**/*.less'],
        use: ['less']
      }),
      postcss({
        extensions: ['.lcss'],
        include: ['**/*.lcss'],
        use: [],
        modules: true,
        namedExports: true
      }),
      // ...
    ]
  };
};
```

BTW I have to add the `include`s, otherwise I'm hitting a bug where the plugin tries to re-parse a stylesheet, but the code has already been transformed to JS. 🤔 