### PR TITLE
Remove error logging in `loadModule`

### DIFF
--- a/src/utils/load-module.js
+++ b/src/utils/load-module.js
@@ -6,7 +6,6 @@ export function loadModule(moduleId) {
     return require(moduleId)
   } catch (error) {
     // Ignore error
-    console.error(error)
   }
 
   // Then, trying to load it relative to CWD

--- a/src/utils/load-module.js
+++ b/src/utils/load-module.js
@@ -4,7 +4,7 @@ export function loadModule(moduleId) {
   // Trying to load module normally (relative to plugin directory)
   try {
     return require(moduleId)
-  } catch (error) {
+  } catch (_) {
     // Ignore error
   }
 


### PR DESCRIPTION
Release 3.6.* introduced the following line: https://github.com/egoist/rollup-plugin-postcss/blob/75306fb54307573dbad9438da92664ced74c63e3/src/utils/load-module.js#L8-L9

Judging from the comment, this wasn't supposed to be published. Now even if one of the modules exists, the error will be thrown if it's not first in the list (i.e. when using `sass` instead of `node-sass`).
