### PR TITLE
Export list of assets in CSS based on `url()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,38 @@ Type: `id => void`
 
 A function to be invoked when an import for CSS file is detected.
 
+### assets
+
+Type: `boolean`<br>
+Default: `false`
+
+Export an object with each asset and its type (`image`, `font`,...) based on `url()` found in imported CSS.
+The exported object interface is:
+
+```typescript
+interface ExportedAssets {
+    [path: string]: "image" | "font" | null
+}
+```
+
+For instance, if your CSS include a background image: 
+
+```css
+div {
+  background: url(/media/background.jpg);
+}
+```
+
+The following const will be exported:
+
+```typescript
+export const assets={
+  '/media/background.jpg': 'image'
+};
+```
+
+_Limitation:_ it will not work with `at-rules` (see [#261](https://github.com/egoist/rollup-plugin-postcss/pull/261))
+
 ## License
 
 MIT &copy; [EGOIST](https://github.com/egoist)

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,8 @@ export default (options = {}) => {
     onlyModules: options.modules === true,
     modules: inferOption(options.modules, false),
     namedExports: options.namedExports,
+    /** List CSS assets */
+    assets: inferOption(options.assets, false),
     /** Automatically CSS modules for .module.xxx files */
     autoModules: options.autoModules,
     /** Options for cssnano */

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -107,12 +107,8 @@ export default {
         postcss.plugin('postcss-extract-assets', () => {
           return function (styles) {
             styles.walkDecls(decl => {
-              if (!decl.value) {
-                return
-              }
-
-              const [, url] = decl.value.match(/url\(['"]?(.*?)['"]?\)/) || [null, null]
-              if (!url) {
+              const [, url] = (decl.value || '').match(/url\(['"]?(.*?)['"]?\)/) || [null, null]
+              if (!url || url.indexOf('data:') === 0 || url.indexOf('#') === 0) {
                 return
               }
 

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -107,7 +107,7 @@ export default {
         postcss.plugin('postcss-extract-assets', () => {
           return function (styles) {
             styles.walkDecls(decl => {
-              const [, url] = (decl.value || '').match(/url\(['"]?(.*?)['"]?\)/) || [null, null]
+              const [, url] = (decl.value || '').match(/url\((?:'(.*?)'|"(.*?)"|(?!['"])(.*?)(?!['"])\))/) || [null, null]
               if (!url || url.indexOf('data:') === 0 || url.indexOf('#') === 0) {
                 return
               }

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -101,30 +101,33 @@ export default {
     }
 
     const shouldListAssets = options.assets
-    const assets = {};
+    const assets = {}
     if (shouldListAssets) {
       plugins.unshift(
         postcss.plugin('postcss-extract-assets', () => {
-          return function(styles, result) {
-            styles.walkDecls(function(decl) {
+          return function (styles) {
+            styles.walkDecls(decl => {
               if (!decl.value) {
                 return
               }
-              const [, url]= decl.value.match(/url\([\'\"]?(.*?)[\'\"]?\)/) || [null, null];
+
+              const [, url] = decl.value.match(/url\(['"]?(.*?)['"]?\)/) || [null, null]
               if (!url) {
                 return
               }
 
               if (url in assets) {
-                return;
+                return
               }
-              let as = null;
-              if (decl.parent.name == 'font-face' && decl.prop == 'src') {
+
+              let as = null
+              if (decl.parent.name === 'font-face' && decl.prop === 'src') {
                 as = 'font'
-              } else if (decl.prop == 'background' || decl.prop == 'background-image') {
+              } else if (decl.prop === 'background' || decl.prop === 'background-image') {
                 as = 'image'
               }
-              assets[url] = as;
+
+              assets[url] = as
             })
           }
         })

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -6,7 +6,7 @@ import { identifier } from 'safe-identifier'
 import humanlizePath from './utils/humanlize-path'
 import normalizePath from './utils/normalize-path'
 
-const imageTags = [
+const imageTags = new Set([
   'background',
   'background-image',
   'list-style',
@@ -17,8 +17,8 @@ const imageTags = [
   'border-image',
   'border-image-source',
   'mask',
-  'mask-image',
-];
+  'mask-image'
+])
 
 const styleInjectPath = require
   .resolve('style-inject/dist/style-inject.es')
@@ -125,8 +125,9 @@ export default {
               if (!matches) {
                 return
               }
+
               for (const match of matches) {
-                const url = match[1] || match[2] || match[3];
+                const url = match[1] || match[2] || match[3]
                 if (!url || url.indexOf('data:') === 0 || url.indexOf('#') === 0) {
                   continue
                 }
@@ -136,8 +137,8 @@ export default {
                 }
 
                 let as = null
-                if (imageTags.indexOf(decl.prop) !== -1
-                  || (decl.parent && decl.parent.name === 'counter-style' && decl.prop === 'symbols')
+                if (imageTags.has(decl.prop) ||
+                  (decl.parent && decl.parent.name === 'counter-style' && decl.prop === 'symbols')
                 ) {
                   as = 'image'
                 } else if (decl.parent && decl.parent.name === 'font-face' && decl.prop === 'src') {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -431,6 +431,15 @@ console.log(css_248z, css_248z$1);
 "
 `;
 
+exports[`listAssets 1`] = `
+"'use strict';
+
+const assets={\\"background.jpg\\":\\"image\\",\\"font.woff2\\":\\"font\\"};
+
+console.log(assets);
+"
+`;
+
 exports[`minimize extract: css code 1`] = `".bar,body{color:red}body{background:red}#sidebar{width:30%;background-color:#faa}#header{color:#6c94be}.pcss{color:red}"`;
 
 exports[`minimize extract: js code 1`] = `

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -434,7 +434,7 @@ console.log(css_248z, css_248z$1);
 exports[`listAssets 1`] = `
 "'use strict';
 
-const assets={\\"background.jpg\\":\\"image\\",\\"font.woff2\\":\\"font\\"};
+const assets={\\"background.jpg\\":\\"image\\",\\"font.woff2\\":\\"font\\",\\"odd.svg\\":\\"image\\",\\"even.svg\\":\\"image\\"};
 
 console.log(assets);
 "

--- a/test/fixtures/assets/index.js
+++ b/test/fixtures/assets/index.js
@@ -1,0 +1,3 @@
+import { assets } from './style.css'
+
+console.log(assets)

--- a/test/fixtures/assets/style.css
+++ b/test/fixtures/assets/style.css
@@ -1,7 +1,15 @@
+html {
+  background: url('background.jpg');
+}
+
 body {
   background: url('background.jpg');
 }
 
 @font-face {
   src: url('font.woff2') format('woff2');
+}
+
+.any {
+  background: url(data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==);
 }

--- a/test/fixtures/assets/style.css
+++ b/test/fixtures/assets/style.css
@@ -1,0 +1,7 @@
+body {
+  background: url('background.jpg');
+}
+
+@font-face {
+  src: url('font.woff2') format('woff2');
+}

--- a/test/fixtures/assets/style.css
+++ b/test/fixtures/assets/style.css
@@ -1,15 +1,27 @@
 html {
+  /* Simple test */
   background: url('background.jpg');
 }
 
 body {
+  /* Duplicate test */
   background: url('background.jpg');
 }
 
 @font-face {
+  /* Font-face test */
   src: url('font.woff2') format('woff2');
 }
 
-.any {
+.ignore-data-uri {
   background: url(data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==);
+}
+
+.ignore-decl-without-url {
+  background: red;
+}
+
+@counter-style list {
+  /* Multiple urls test */
+  symbols: url(odd.svg) url("even.svg");
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -413,3 +413,16 @@ test('augmentChunkHash', async () => {
   const barHash = barOne.fileName.split('.')[1]
   expect(barHash).not.toEqual(fooHash) // Verify that foo and bar does not hash to the same
 })
+
+test('listAssets', async () => {
+  const result = await write({
+    input: 'assets/index.js',
+    outDir: 'listAssets',
+    options: {
+      inject: false,
+      extract: false,
+      assets: true
+    }
+  })
+  expect(await result.jsCode()).toMatchSnapshot()
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,6 +44,7 @@ export type PostCSSPluginConf = {
 	sourceMap?: boolean | 'inline';
 	include?: Parameters<CreateFilter>[0];
 	exclude?: Parameters<CreateFilter>[1];
+	assets?: boolean;
 };
 
 export default function (options: Readonly<PostCSSPluginConf>): Plugin


### PR DESCRIPTION
The purpose of this POC is to list the `url` used in CSS values. This list is exported in Javascript and can be used later to generate [content preloading header (`<link rel="preload">`)](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) or to do some HTTP/2 pushes.

For instance, if your CSS include a background image:

```css
div {
  background: url(/media/background.jpg);
}
```

The following `const` will be exported:

```javascript
export const assets={
  '/media/background.jpg': 'image'
};
```

The object key is the url and the value is the `as` value you should use. This value is build from CSS keywords, properties, parent... If not any `as` value is found, it returns `null`.