### PR TITLE
Pass outputSourceFiles to less loader

### DIFF
--- a/src/less-loader.js
+++ b/src/less-loader.js
@@ -13,7 +13,9 @@ export default {
 
     let { css, map, imports } = await pify(less.render.bind(less))(code, {
       ...this.options,
-      sourceMap: this.sourceMap && {},
+      sourceMap: this.sourceMap && {
+        outputSourceFiles: true
+      },
       filename: this.id
     })
 

--- a/src/stylus-loader.js
+++ b/src/stylus-loader.js
@@ -1,3 +1,5 @@
+import path from 'path'
+import fs from 'fs'
 import pify from 'pify'
 import { loadModule } from './utils/load-module'
 
@@ -17,6 +19,16 @@ export default {
     })
 
     const css = await pify(style.render.bind(style))()
+
+    if (style?.sourcemap?.sources) {
+      const sourcesContent = await Promise.all(style.sourcemap.sources.map(async (file) => {
+        const absPath = path.resolve(file)
+        const source = await pify(fs.readFile)(absPath, 'utf8')
+        return source.toString()
+      }))
+      style.sourcemap.sourcesContent = sourcesContent
+    }
+   
     const deps = style.deps()
     for (const dep of deps) {
       this.dependencies.add(dep)


### PR DESCRIPTION
This matches the output of sass-loader (includes "sourcesContent" property on sourcemap),
and fixes sourcemaps for less files when dest path isn't served on a public URL.

