### PR TITLE
Allow syntax specific data to be specified

### DIFF
--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -28,13 +28,16 @@ export default {
     return new Promise((resolve, reject) => {
       const sass = loadSassOrThrow()
       const render = pify(sass.render.bind(sass))
-      const data = this.options.data || ''
+      const indented = /\.sass$/.test(this.id)
+      const data = (this.options.data && this.options.data.scss && this.options.data.sass) ?
+        (indented ? this.options.data.sass : this.options.data.scss) :
+        (this.options.data || '')
       return workQueue.add(() =>
         render({
           ...this.options,
           file: this.id,
           data: data + code,
-          indentedSyntax: /\.sass$/.test(this.id),
+          indentedSyntax: indented,
           sourceMap: this.sourceMap,
           importer: [
             (url, importer, done) => {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -839,6 +839,82 @@ styleInject(css_248z);
 "
 `;
 
+exports[`sass data-prepend-mixed: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css_248z = \\".special {\\\\n  color: pink; }\\\\n\\";
+styleInject(css_248z);
+
+var css_248z$1 = \\".special {\\\\n  color: pink; }\\\\n\\";
+styleInject(css_248z$1);
+"
+`;
+
+exports[`sass data-prepend-mixed: js code 2`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css_248z = \\".special {\\\\n  color: pink; }\\\\n\\";
+styleInject(css_248z);
+
+var css_248z$1 = \\".special {\\\\n  color: pink; }\\\\n\\";
+styleInject(css_248z$1);
+"
+`;
+
 exports[`sass default: js code 1`] = `
 "'use strict';
 

--- a/test/fixtures/sass-data-prepend/mixed.js
+++ b/test/fixtures/sass-data-prepend/mixed.js
@@ -1,0 +1,2 @@
+import './style.scss'
+import './style.sass'

--- a/test/fixtures/sass-data-prepend/style.sass
+++ b/test/fixtures/sass-data-prepend/style.sass
@@ -1,0 +1,2 @@
+.special
+  color: $special-color

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -364,6 +364,27 @@ snapshotMany('sass', [
     }
   },
   {
+    title: 'data-prepend-mixed',
+    input: 'sass-data-prepend/mixed.js',
+    options: {
+      use: [
+        [
+          'sass',
+          { data: { sass: '@import \'prepend\'\n', scss: '@import \'prepend\';' } }
+        ]
+      ]
+    }
+  },
+  {
+    title: 'data-prepend-mixed',
+    input: 'sass-data-prepend/mixed.js',
+    options: {
+      use: {
+        sass: { data: { sass: '@import \'prepend\'\n', scss: '@import \'prepend\';' } }
+      }
+    }
+  },
+  {
     title: 'import',
     input: 'sass-import/index.js'
   }


### PR DESCRIPTION
Make the data option passed to the SASS loader granular based on the specific syntax of the file (SASS vs SCSS). This is primarily intended to support alternate `@import` syntax when processing different files (SASS requires newline termination, SCSS requires semicolon), but can be used for any purpose where the inserted data must differ based on the syntax.

This enables support for inserting data in mixed mode projects (e.g. [vuetify](https://github.com/vuetifyjs/vuetify)); ideally, a single syntax would be used consistently but in reality, many third-party projects blend both types.