### PR TITLE
Allow `modules` options without disabling autoModules

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -71,7 +71,7 @@ export default {
 
     const modulesExported = {}
     const autoModules = options.autoModules !== false && isModuleFile(this.id)
-    const supportModules = options.modules || autoModules
+    const supportModules = options.autoModules === true ? autoModules : options.modules || autoModules
     if (supportModules) {
       plugins.unshift(
         require('postcss-modules')({


### PR DESCRIPTION
This adds an explicit `autoModules:true` option that forces isModuleFile() behavior even if `options.modules` is truthy. This is important because `options.modules` can be necessary to configure the behavior of postcss-modules, but currently doing so also forces postcss-modules to be run on 100% of files.

### Example:

```
postcss({
  autoModules: true,
  modules: {
    generateScopedName: '_[hash:base64:5]'
  }
})
```

### Current Behavior:

The above object value for `options.modules` is truthy, which causes `postcss-modules` to be executed against all files.

### Behavior with this change:

Since `autoModules` is explicitly set to `true`, `options.modules` being a (truthy) object does not override automatic module behavior, so `postcss-modules` is only executed against files ending in `.module.css`.

