### PR TITLE
fix: allow module config while using autoModules (#281)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export default (options = {}) => {
     /** Extract CSS */
     extract: typeof options.extract === 'undefined' ? false : options.extract,
     /** CSS modules */
+    onlyModules: options.modules === true,
     modules: inferOption(options.modules, false),
     namedExports: options.namedExports,
     /** Automatically CSS modules for .module.xxx files */

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -70,8 +70,9 @@ export default {
     const shouldInject = options.inject
 
     const modulesExported = {}
-    const autoModules = options.autoModules !== false && isModuleFile(this.id)
-    const supportModules = options.modules || autoModules
+    const autoModules = options.autoModules !== false && options.onlyModules !== true
+    const isAutoModule = autoModules && isModuleFile(this.id)
+    const supportModules = autoModules ? isAutoModule : options.modules
     if (supportModules) {
       plugins.unshift(
         require('postcss-modules')({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -198,6 +198,7 @@ snapshotMany('modules', [
     title: 'inject-object',
     input: 'css-modules/index.js',
     options: {
+      autoModules: false,
       modules: {
         getJSON() {
           //


### PR DESCRIPTION
This includes a fix for #281

Comparison of the options logic (IS / SHOULD columns):
| Case |                   | opt autoModules | opt modules | -- will be module? |  IS | SHOULD |
|------|-------------------|-----------------|-------------|--------------------|----:|-------:|
| 1    | styles.css        | false           | false       |                    |     |        |
| 2    | ...               | false           | true        |                    | yes |    yes |
| 3    | ...               | true            | false       |                    |     |        |
| 4    | ...               | true            | true        |                    | yes |    yes |
| 5    | ...               | false           | {}          |                    | yes |    yes |
| 6    | ...               | true            | {}          |                    | yes |        |
| 7    | styles.module.css | false           | false       |                    |     |        |
| 8    | ...               | false           | true        |                    | yes |    yes |
| 9    | ...               | true            | false       |                    | yes |    yes |
| 10   | ...               | true            | true        |                    | yes |    yes |
| 11   | ...               | false           | {}          |                    | yes |    yes |
| 12   | ...               | true            | {}          |                    | yes |    yes |

I hope I didnt make any errors in the table LMAO

- Refs developit/microbundle#653, developit/microbundle#617