### PR TITLE
fix: Add types file to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Seamless integration between Rollup and PostCSS",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "types/index.d.ts"
   ],
   "scripts": {
     "test": "npm run lint && jest",


### PR DESCRIPTION
Hi there :wave:

While using this module in a project I noticed that the types file specified
doesn't get published to npm when this package is published. I've added it in in this PR.

Thanks for maintaining this module!
