### PR TITLE
fix: add dynamic imports to the end of the css file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,13 @@ function getRecursiveImportOrder(id, getModuleInfo, seen = new Set()) {
   seen.add(id)
 
   const result = [id]
-  getModuleInfo(id).importedIds.forEach(importFile => {
+  const moduleInfo = getModuleInfo(id)
+
+  moduleInfo.importedIds.forEach(importFile => {
+    result.push(...getRecursiveImportOrder(importFile, getModuleInfo, seen))
+  })
+
+  moduleInfo.dynamicallyImportedIds.forEach(importFile => {
     result.push(...getRecursiveImportOrder(importFile, getModuleInfo, seen))
   })
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -211,7 +211,15 @@ a {
 .component-module_box {
   color: blue;
 }
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5jc3MiLCJiYXIubW9kdWxlLmNzcyIsIm5lc3RlZC5jc3MiLCJjb21wb25lbnQubW9kdWxlLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtFQUNFLFVBQVU7QUFDWjs7QUNGQTtFQUNFLFVBQVU7QUFDWjs7QUNGQTtFQUNFLGlCQUFpQjtBQUNuQjs7QUNGQTtFQUNFLFdBQVc7QUFDYiIsImZpbGUiOiJidW5kbGUuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYm9keSB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuYmFyIHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsImEge1xuICBmb250LXdlaWdodDogYm9sZDtcbn1cbiIsIi5ib3gge1xuICBjb2xvcjogYmx1ZTtcbn0iXX0=*/"
+.dynamicNested {
+  color: tomato;
+}
+
+.dynamic-module_dynamic {
+  color: tomato;
+}
+
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5jc3MiLCJiYXIubW9kdWxlLmNzcyIsIm5lc3RlZC5jc3MiLCJjb21wb25lbnQubW9kdWxlLmNzcyIsIm5lc3RlZC1keW5hbWljIG1vZHVsZS5jc3MiLCJkeW5hbWljLm1vZHVsZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFDRSxVQUFVO0FBQ1o7O0FDRkE7RUFDRSxVQUFVO0FBQ1o7O0FDRkE7RUFDRSxpQkFBaUI7QUFDbkI7O0FDRkE7RUFDRSxXQUFXO0FBQ2I7QUNGQTtFQUNFLGFBQWE7QUFDZjs7QUNGQTtFQUNFLGFBQWE7QUFDZiIsImZpbGUiOiJidW5kbGUuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYm9keSB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuYmFyIHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsImEge1xuICBmb250LXdlaWdodDogYm9sZDtcbn1cbiIsIi5ib3gge1xuICBjb2xvcjogYmx1ZTtcbn0iLCIuZHluYW1pY05lc3RlZCB7XG4gIGNvbG9yOiB0b21hdG87XG59XG4iLCIuZHluYW1pYyB7XG4gIGNvbG9yOiB0b21hdG87XG59XG4iXX0=*/"
 `;
 
 exports[`extract nested: js code 1`] = `
@@ -221,7 +229,11 @@ var bar = {\\"bar\\":\\"bar-module_bar\\"};
 
 var component = {\\"box\\":\\"component-module_box\\"};
 
-console.log(bar, component);
+(async () => {
+  // eslint-disable-next-line node/no-unsupported-features/es-syntax
+  const dynamicModule = await new Promise(function (resolve) { resolve(require('./dynamic-23a2f1cd.js')); });
+  console.log(bar, component, dynamicModule);
+})();
 "
 `;
 
@@ -241,7 +253,15 @@ a {
 .component-module_box {
   color: blue;
 }
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5jc3MiLCJiYXIubW9kdWxlLmNzcyIsIm5lc3RlZC5jc3MiLCJjb21wb25lbnQubW9kdWxlLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtFQUNFLFVBQVU7QUFDWjs7QUNGQTtFQUNFLFVBQVU7QUFDWjs7QUNGQTtFQUNFLGlCQUFpQjtBQUNuQjs7QUNGQTtFQUNFLFdBQVc7QUFDYiIsImZpbGUiOiJidW5kbGUuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYm9keSB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuYmFyIHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsImEge1xuICBmb250LXdlaWdodDogYm9sZDtcbn1cbiIsIi5ib3gge1xuICBjb2xvcjogYmx1ZTtcbn0iXX0=*/"
+.dynamicNested {
+  color: tomato;
+}
+
+.dynamic-module_dynamic {
+  color: tomato;
+}
+
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5jc3MiLCJiYXIubW9kdWxlLmNzcyIsIm5lc3RlZC5jc3MiLCJjb21wb25lbnQubW9kdWxlLmNzcyIsIm5lc3RlZC1keW5hbWljIG1vZHVsZS5jc3MiLCJkeW5hbWljLm1vZHVsZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFDRSxVQUFVO0FBQ1o7O0FDRkE7RUFDRSxVQUFVO0FBQ1o7O0FDRkE7RUFDRSxpQkFBaUI7QUFDbkI7O0FDRkE7RUFDRSxXQUFXO0FBQ2I7QUNGQTtFQUNFLGFBQWE7QUFDZjs7QUNGQTtFQUNFLGFBQWE7QUFDZiIsImZpbGUiOiJidW5kbGUuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYm9keSB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuYmFyIHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsImEge1xuICBmb250LXdlaWdodDogYm9sZDtcbn1cbiIsIi5ib3gge1xuICBjb2xvcjogYmx1ZTtcbn0iLCIuZHluYW1pY05lc3RlZCB7XG4gIGNvbG9yOiB0b21hdG87XG59XG4iLCIuZHluYW1pYyB7XG4gIGNvbG9yOiB0b21hdG87XG59XG4iXX0=*/"
 `;
 
 exports[`extract nested-delay-resolve: js code 1`] = `
@@ -251,7 +271,11 @@ var bar = {\\"bar\\":\\"bar-module_bar\\"};
 
 var component = {\\"box\\":\\"component-module_box\\"};
 
-console.log(bar, component);
+(async () => {
+  // eslint-disable-next-line node/no-unsupported-features/es-syntax
+  const dynamicModule = await new Promise(function (resolve) { resolve(require('./dynamic-4354553e.js')); });
+  console.log(bar, component, dynamicModule);
+})();
 "
 `;
 

--- a/test/fixtures/nested/component.js
+++ b/test/fixtures/nested/component.js
@@ -1,3 +1,10 @@
 import component from './component.module.css'
 
-export default component
+export { component }
+
+export default function test() {
+  // eslint-disable-next-line node/no-unsupported-features/es-syntax
+  return import('./nested-dynamic').then(() => {
+    return 'nested-dynamic'
+  })
+}

--- a/test/fixtures/nested/dynamic.js
+++ b/test/fixtures/nested/dynamic.js
@@ -1,0 +1,3 @@
+import dynamic from './dynamic.module.css'
+
+console.log(dynamic)

--- a/test/fixtures/nested/dynamic.module.css
+++ b/test/fixtures/nested/dynamic.module.css
@@ -1,0 +1,3 @@
+.dynamic {
+  color: tomato;
+}

--- a/test/fixtures/nested/index.js
+++ b/test/fixtures/nested/index.js
@@ -1,6 +1,10 @@
 import './foo.css'
 import bar from './bar.module.css'
 import './nested'
-import component from './component'
+import { component } from './component';
 
-console.log(bar, component)
+(async () => {
+  // eslint-disable-next-line node/no-unsupported-features/es-syntax
+  const dynamicModule = await import('./dynamic')
+  console.log(bar, component, dynamicModule)
+})()

--- a/test/fixtures/nested/nested-dynamic module.css
+++ b/test/fixtures/nested/nested-dynamic module.css
@@ -1,0 +1,3 @@
+.dynamicNested {
+  color: tomato;
+}

--- a/test/fixtures/nested/nested-dynamic.js
+++ b/test/fixtures/nested/nested-dynamic.js
@@ -1,0 +1,3 @@
+import dynamic from './nested-dynamic module.css'
+
+console.log(dynamic)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,7 +50,8 @@ async function write({
   })
   await bundle.write({
     format: 'cjs',
-    file: path.join(outDir, 'bundle.js')
+    dir: outDir,
+    entryFileNames: 'bundle.js'
   })
   let cssCodePath = path.join(outDir, 'bundle.css')
   if (typeof options.extract === 'string') {


### PR DESCRIPTION
https://github.com/egoist/rollup-plugin-postcss/pull/295 did not take care of dynamicImported modules. These modules were included but at the top of the css file. We can't know the execution sequence of these imports but I've added them to the recursive function so they are ranked lower than regular imports.

Fixes https://github.com/egoist/rollup-plugin-postcss/issues/316