### PR TITLE
BREAKING CHANGE: move postcss peerdep 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "style-inject": "^0.3.0"
   },
   "peerDependencies": {
-    "postcss": "^8.1.14"
+    "postcss": "8.x"
   },
   "xo": {
     "extends": "rem",


### PR DESCRIPTION
This commit should trigger semantic versioning and also put peer dep to 8.x instead of 8.1.14