### PR TITLE
Improve autoModules option documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Default: `true`
 
 Automatically enable CSS modules for `.module.css` `.module.sss` `.module.scss` `.module.sass` `.module.styl` `.module.stylus` `.module.less` files.
 
+**Warning: when set to `true`, custom rules defined in `modules` option will only be applied to files with `.module.*` extension. If set to `false`, your custom `modules` rules will be applied to every CSS file regardless of its extension (e.g. files with `.module.*` extension *and* others like `.sass` or `.scss`).**
+
 ### namedExports
 
 Type: `boolean` `function`<br>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Default: `true`
 
 Automatically enable CSS modules for `.module.css` `.module.sss` `.module.scss` `.module.sass` `.module.styl` `.module.stylus` `.module.less` files.
 
-**Warning: when set to `true`, custom rules defined in `modules` option will only be applied to files with `.module.*` extension. If set to `false`, your custom `modules` rules will be applied to every CSS file regardless of its extension (e.g. files with `.module.*` extension *and* others like `.sass` or `.scss`).**
+**Warning: when set to `true`, custom options for `postcss-modules` defined in the `modules` option will only be applied to files with `.module.*` extension. If set to `false`, your `postcss-modules` options in `modules` will be applied to every CSS file regardless of its extension (e.g. files with `.module.*` extension *and* others like `.sass` or `.scss`).**
 
 ### namedExports
 


### PR DESCRIPTION
Hi there!

While we were working on our Rollup config, we found that the `postcss-modules` options that we were configuring in the `modules` option were not being applied to our CSS classes, and the output was wrong. After testing different changes for a while, we found out that when the `autoModules` option was set to its `true` default value, the plugin wouldn't apply our custom `postcss-modules` options unless the CSS file had a `.module.*` extension type. To avoid this, and have the plugin apply our custom config in every file regardless of its extension, we needed to set the `autoModules` option to `false`.

We thought it could be useful to update the README documentation about these plugin options with this use case, in case someone else is having the same issue.

I hope it helps, any comment or suggestion on how to improve the writing or additional clarifications needed to make it understandable... are welcome :)

![gif](https://media.giphy.com/media/3oz8xIsloV7zOmt81G/giphy.gif)