### PR TITLE
chore: update to cssnano@4.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "concat-with-sourcemaps": "^1.1.0",
-    "cssnano": "^4.1.10",
+    "cssnano": "^4.1.11",
     "import-cwd": "^3.0.0",
     "p-queue": "^6.6.2",
     "pify": "^5.0.0",


### PR DESCRIPTION
A patch was back-ported to cssnano@4 to patch [CVE-2021-28092](https://nvd.nist.gov/vuln/detail/CVE-2021-28092): https://github.com/cssnano/cssnano/releases/tag/v4.1.11