### PR TITLE
Add support for `dir-dependency` message type

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -144,6 +144,8 @@ export default {
     for (const message of result.messages) {
       if (message.type === 'dependency') {
         this.dependencies.add(message.file)
+      } else if (message.type === 'dir-dependency') {
+        this.dependencies.add(message.dir)
       }
     }
 


### PR DESCRIPTION
This pull request adds support for the `dir-dependency` message type, [detailed in the PostCSS docs](https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#3-dependencies).