### PR TITLE
fix: support nested filenames in bundle for different OS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,9 +171,10 @@ export default (options = {}) => {
 
         const concat = new Concat(true, fileName, '\n')
         const entries = [...extracted.values()]
+        const relativePath = path.relative(dir, file)
         const { modules, facadeModuleId } = bundle[
-          normalizePath(path.relative(dir, file))
-        ]
+          normalizePath(relativePath)
+        ] || bundle[relativePath]
 
         if (modules) {
           const moduleIds = getRecursiveImportOrder(


### PR DESCRIPTION
In my project `bundle` sometimes contained nested path like `somePath\index.css` but `normalizePath` function is changing all back slashes to forward slashes. So if my `bundle` contains field `somePath\index.css` and `normalizePath` returned `somePath/index.css` I ended up with error:
`[!] (plugin postcss) TypeError: Cannot read property 'modules' of undefined`
This PR is fixing it by additionally checking bundle for non-normalizePath. 