### PR TITLE
Replaced style-inject with style-implant

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Default: `true`
 
 Inject CSS into `<head>`, it's always `false` when `extract: true`.
 
-You can also use it as options for [`style-inject`](https://github.com/egoist/style-inject#options).
+You can also use it as options for [`style-implant`](https://github.com/ivoilic/style-implant#options).
 
 It can also be a `function` , returning a `string` which is js code.
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "resolve": "^1.19.0",
     "rollup-pluginutils": "^2.8.2",
     "safe-identifier": "^0.4.2",
-    "style-inject": "^0.3.0"
+    "style-implant": "^0.3.x"
   },
   "peerDependencies": {
     "postcss": "8.x"

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -6,8 +6,8 @@ import { identifier } from 'safe-identifier'
 import humanlizePath from './utils/humanlize-path'
 import normalizePath from './utils/normalize-path'
 
-const styleInjectPath = require
-  .resolve('style-inject/dist/style-inject.es')
+const styleImplantPath = require
+  .resolve('style-implant/dist/es/style-implant')
   .replace(/[\\/]+/g, '/')
 
 function loadConfig(id, { ctx: configOptions, path: configPath }) {
@@ -209,8 +209,8 @@ export default {
 
     if (!shouldExtract && shouldInject) {
       output += typeof options.inject === 'function' ? options.inject(cssVariableName, this.id) : '\n' +
-        `import styleInject from '${styleInjectPath}';\n` +
-        `styleInject(${cssVariableName}${Object.keys(options.inject).length > 0 ?
+        `import styleImplant from '${styleImplantPath}';\n` +
+        `styleImplant(${cssVariableName}${Object.keys(options.inject).length > 0 ?
           `,${JSON.stringify(options.inject)}` :
           ''
         });`


### PR DESCRIPTION
### Summary
Replaces [style-inject](https://github.com/egoist/style-inject) with [style-implant](https://github.com/ivoilic/style-implant) which is being actively developed, has additional options, and doesn't include any breaking changes!

### Background
I'm submitting this PR because of my own experience attempting to bugfix a project that was using rollup-plugin-postcss. I found my styles where being injected at the bottom rather than top of the head causing them override other styles. I realized this could be "fixed" by passing in an options object for the dependency `style-inject`. However, with literally only one option, open PRs for missing features, and no updates in 4 years `style-inject` is lacking. I've created a modern version of this library under the name `style-implant`. I've done my best to make it a drop in replacement for `style-inject` without any breaking changes besides the folder structure of the package itself.

### Improvements
In addition to adding TypeScript support and tests, `style-implant` adds the ability to add attributes to your injected style tags and preserve the order of style tags injected in the top of the head.