### PR TITLE
fix: prioritize dart-sass over deprecated node-sass

### DIFF
--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -19,7 +19,7 @@ const getUrlOfPartial = url => {
 const resolvePromise = pify(resolve)
 
 // List of supported SASS modules in the order of preference
-const sassModuleIds = ['node-sass', 'sass']
+const sassModuleIds = ['sass', 'node-sass']
 
 /* eslint import/no-anonymous-default-export: [2, {"allowObject": true}] */
 export default {


### PR DESCRIPTION
# What does this do?

Prioritizes dart-sass (`sass`) over `node-sass` when both are available

# Why?

[`node-sass` is deprecated](https://www.npmjs.com/package/node-sass), as is its underlying LibSass.

Modern Sass features such as `@use` [cannot and will not be supported by `node-sass`](https://github.com/sass/node-sass/issues/2886)

In projects where both dependencies are available, this change will prevent the deprecated `node-sass` from running against modern SCSS code that may require dart-sass to compile.

While a configurable option for the preferred loader would be a more robust solution, it would require much more extensive changes to the plugin. This is a simple solution that will resolve the core problems experienced in issues #321 and #304, and involves minimal changes to the plugin code, leveraging the already-existing functionality of having a priority-ordered list of Sass modules.