### PR TITLE
Fixes tree-shaking in css modules #293

### DIFF
--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -193,7 +193,7 @@ export default {
     if (shouldExtract) {
       output += `export default ${JSON.stringify(modulesExported[this.id])};`;
       extracted = {
-        id: _this.id,
+        id: this.id,
         code: result.css,
         map: outputMap
       };

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -191,25 +191,25 @@ export default {
 
     const cssVariableName = identifier('css', true)
     if (shouldExtract) {
-      output += `export default ${JSON.stringify(modulesExported[_this.id])};`;
+      output += `export default ${JSON.stringify(modulesExported[this.id])};`;
       extracted = {
         id: _this.id,
         code: result.css,
         map: outputMap
       };
     } else {
-      const module = supportModules ? JSON.stringify(modulesExported[_this.id]) : cssVariableName;
-      output += 
-        `var ${cssVariableName} = ${JSON.stringify(result.css)};\n` + 
-        `var styleMapping = ${module};\n` + 
+      const module = supportModules ? JSON.stringify(modulesExported[this.id]) : cssVariableName;
+      output +=
+        `var ${cssVariableName} = ${JSON.stringify(result.css)};\n` +
+        `var styleMapping = ${module};\n` +
         `export var stylesheet=${JSON.stringify(result.css)};`;
     }
 
     if (!shouldExtract && shouldInject) {
-      output += typeof options.inject === 'function' ? options.inject(cssVariableName, _this.id) : '\n' + 
-        `import styleInject from '${styleInjectPath}';\n` + 
-        `export default /*#__PURE__*/(function() {\n  styleInject(${cssVariableName}${Object.keys(options.inject).length > 0 ? 
-          `,${JSON.stringify(options.inject)}` : 
+      output += typeof options.inject === 'function' ? options.inject(cssVariableName, this.id) : '\n' +
+        `import styleInject from '${styleInjectPath}';\n` +
+        `export default /*#__PURE__*/(function() {\n  styleInject(${cssVariableName}${Object.keys(options.inject).length > 0 ?
+          `,${JSON.stringify(options.inject)}` :
           ''
         });\n  return styleMapping;\n})();`;
     }

--- a/src/postcss-loader.js
+++ b/src/postcss-loader.js
@@ -191,29 +191,27 @@ export default {
 
     const cssVariableName = identifier('css', true)
     if (shouldExtract) {
-      output += `export default ${JSON.stringify(modulesExported[this.id])};`
+      output += `export default ${JSON.stringify(modulesExported[_this.id])};`;
       extracted = {
-        id: this.id,
+        id: _this.id,
         code: result.css,
         map: outputMap
-      }
+      };
     } else {
-      const module = supportModules ?
-        JSON.stringify(modulesExported[this.id]) :
-        cssVariableName
-      output +=
-        `var ${cssVariableName} = ${JSON.stringify(result.css)};\n` +
-        `export default ${module};\n` +
-        `export var stylesheet=${JSON.stringify(result.css)};`
+      const module = supportModules ? JSON.stringify(modulesExported[_this.id]) : cssVariableName;
+      output += 
+        `var ${cssVariableName} = ${JSON.stringify(result.css)};\n` + 
+        `var styleMapping = ${module};\n` + 
+        `export var stylesheet=${JSON.stringify(result.css)};`;
     }
 
     if (!shouldExtract && shouldInject) {
-      output += typeof options.inject === 'function' ? options.inject(cssVariableName, this.id) : '\n' +
-        `import styleInject from '${styleInjectPath}';\n` +
-        `styleInject(${cssVariableName}${Object.keys(options.inject).length > 0 ?
-          `,${JSON.stringify(options.inject)}` :
+      output += typeof options.inject === 'function' ? options.inject(cssVariableName, _this.id) : '\n' + 
+        `import styleInject from '${styleInjectPath}';\n` + 
+        `export default /*#__PURE__*/(function() {\n  styleInject(${cssVariableName}${Object.keys(options.inject).length > 0 ? 
+          `,${JSON.stringify(options.inject)}` : 
           ''
-        });`
+        });\n  return styleMapping;\n})();`;
     }
 
     return {


### PR DESCRIPTION
Thanks to @danlevy1's fix, it's not possible to do tree-shaking with postcss.

It's tested, but feel free to validate it. 😊

Reference to the issue: https://github.com/egoist/rollup-plugin-postcss/issues/293#issuecomment-789398282