### PR TITLE
fix: order multiple inputs correctly

### DIFF
--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -251,6 +251,52 @@ console.log(foo, bar);
 "
 `;
 
+exports[`extract multiple-inputs-resolve: css code 1`] = `
+".should-be-first {
+  color: red;
+}
+
+.from-index {
+  color: red;
+}
+
+.from-other {
+  color: blue;
+}
+
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpcnN0QW5kU2hhcmVkLmNzcyIsImJ1bmRsZS5jc3MiLCJvdGhlci5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFDRSxVQUFVO0FBQ1o7O0FDRkE7RUFDRSxVQUFVO0FBQ1o7O0FDRkE7RUFDRSxXQUFXO0FBQ2IiLCJmaWxlIjoiaW5kZXguY3NzIiwic291cmNlc0NvbnRlbnQiOlsiLnNob3VsZC1iZS1maXJzdCB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuZnJvbS1pbmRleCB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuZnJvbS1vdGhlciB7XG4gIGNvbG9yOiBibHVlO1xufVxuIl19*/"
+`;
+
+exports[`extract multiple-inputs-resolve: js code 1`] = `
+"'use strict';
+
+console.log('here to prevent warnings');
+"
+`;
+
+exports[`extract multiple-inputs-resolve-reverse: css code 1`] = `
+".should-be-first {
+  color: red;
+}
+
+.from-other {
+  color: blue;
+}
+
+.from-index {
+  color: red;
+}
+
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpcnN0QW5kU2hhcmVkLmNzcyIsIm90aGVyLmNzcyIsImJ1bmRsZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFDRSxVQUFVO0FBQ1o7O0FDRkE7RUFDRSxXQUFXO0FBQ2I7O0FDRkE7RUFDRSxVQUFVO0FBQ1oiLCJmaWxlIjoiaW5kZXguY3NzIiwic291cmNlc0NvbnRlbnQiOlsiLnNob3VsZC1iZS1maXJzdCB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuZnJvbS1vdGhlciB7XG4gIGNvbG9yOiBibHVlO1xufVxuIiwiLmZyb20taW5kZXgge1xuICBjb2xvcjogcmVkO1xufVxuIl19*/"
+`;
+
+exports[`extract multiple-inputs-resolve-reverse: js code 1`] = `
+"'use strict';
+
+console.log('here to prevent warnings');
+"
+`;
+
 exports[`extract nested: css code 1`] = `
 "body {
   color: red;

--- a/test/fixtures/multiple-inputs/bundle.css
+++ b/test/fixtures/multiple-inputs/bundle.css
@@ -1,0 +1,3 @@
+.from-index {
+  color: red;
+}

--- a/test/fixtures/multiple-inputs/bundle.js
+++ b/test/fixtures/multiple-inputs/bundle.js
@@ -1,0 +1,4 @@
+import './firstAndShared.css'
+import './bundle.css'
+
+console.log('here to prevent warnings')

--- a/test/fixtures/multiple-inputs/firstAndShared.css
+++ b/test/fixtures/multiple-inputs/firstAndShared.css
@@ -1,0 +1,3 @@
+.should-be-first {
+  color: red;
+}

--- a/test/fixtures/multiple-inputs/other.css
+++ b/test/fixtures/multiple-inputs/other.css
@@ -1,0 +1,3 @@
+.from-other {
+  color: blue;
+}

--- a/test/fixtures/multiple-inputs/other.js
+++ b/test/fixtures/multiple-inputs/other.js
@@ -1,0 +1,4 @@
+import './firstAndShared.css'
+import './other.css'
+
+console.log('here to prevent warnings')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,16 +42,20 @@ async function write({
   }
 
   outDir = fixture('dist', outDir)
+  const multipleInputs = Array.isArray(input)
+  const formattedInput = multipleInputs
+    ? input.map((i) => fixture(i))
+    : fixture(input)
   const bundle = await rollup({
-    input: fixture(input),
+    input: formattedInput,
     plugins: [postcss(postCssOptions), delayResolve && lateResolve].filter(
       Boolean
     )
   })
-  await bundle.write({
-    format: 'cjs',
-    file: path.join(outDir, 'bundle.js')
-  })
+  const writeOptions = multipleInputs
+    ? { format: 'cjs', dir: outDir }
+    : { format: 'cjs', file: path.join(outDir, 'bundle.js') }
+  await bundle.write(writeOptions)
   let cssCodePath = path.join(outDir, 'bundle.css')
   if (typeof options.extract === 'string') {
     cssCodePath = path.isAbsolute(options.extract) ? options.extract : path.join(outDir, options.extract)
@@ -336,6 +340,24 @@ snapshotMany('extract', [
       extract: true,
       delayResolve: true
     }
+  },
+  {
+    title: 'multiple-inputs-resolve',
+    input: ['multiple-inputs/bundle.js', 'multiple-inputs/other.js'],
+    options: {
+      sourceMap: 'inline',
+      extract: 'index.css',
+      delayResolve: true,
+    },
+  },
+  {
+    title: 'multiple-inputs-resolve-reverse',
+    input: ['multiple-inputs/other.js', 'multiple-inputs/bundle.js'],
+    options: {
+      sourceMap: 'inline',
+      extract: 'index.css',
+      delayResolve: true,
+    },
   }
 ])
 


### PR DESCRIPTION
See the issue here: https://github.com/egoist/rollup-plugin-postcss/issues/461.

## Summary of the problem

When using multiple inputs in rollup, css output from any non-first inputs that do not exist in the first input are placed at the top of the output and are ordered by resolve order, causing css output for multiple inputs to be non-deterministic.

## Summary of the fix

In order to fix this problem, we need to trace all the places in which we are importing css and sort based on all those sources.  I needed to expand some of the functions to allow for multiple entry paths, but was able to keep the `seen` checking to prevent multiple checks of shared files.

Tests were added to demonstrate that the fix works.